### PR TITLE
Add SWR provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ downloads/
 eggs/
 .eggs/
 lib/
+!lib/
+!lib/*.ts
 lib64/
 parts/
 sdist/

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import "./globals.css";
 import { SocketProvider } from "./socket-context";
 import { ReactNode, useState } from 'react';
+import { SWRProvider } from '../lib/swr';
 import Link from 'next/link';
 import { SessionProvider, signIn, signOut, useSession } from 'next-auth/react';
 
@@ -23,11 +24,13 @@ function Shell({ children }: { children: ReactNode }) {
   const toggleTheme = () => setTheme(t => (t === 'light' ? 'dark' : 'light'));
 
   return (
-    <SessionProvider>
-      <ShellContent theme={theme} toggleTheme={toggleTheme}>
-        {children}
-      </ShellContent>
-    </SessionProvider>
+    <SWRProvider>
+      <SessionProvider>
+        <ShellContent theme={theme} toggleTheme={toggleTheme}>
+          {children}
+        </ShellContent>
+      </SessionProvider>
+    </SWRProvider>
   );
 }
 

--- a/lib/swr.tsx
+++ b/lib/swr.tsx
@@ -1,0 +1,8 @@
+'use client'
+import { SWRConfig } from 'swr'
+
+export const fetcher = (url: string) => fetch(url).then(res => res.json())
+
+export function SWRProvider({ children }: { children: React.ReactNode }) {
+  return <SWRConfig value={{ fetcher }}>{children}</SWRConfig>
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "next": "^15.4.5",
         "next-auth": "^4.24.11",
         "react": "^19.1.1",
-        "react-dom": "^19.1.1"
+        "react-dom": "^19.1.1",
+        "swr": "^2.3.4"
       },
       "devDependencies": {
         "@types/node": "24.1.0",
@@ -2839,6 +2840,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/detect-libc": {
@@ -6382,6 +6392,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.4.tgz",
+      "integrity": "sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -6690,6 +6713,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/uuid": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "next": "^15.4.5",
     "next-auth": "^4.24.11",
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "swr": "^2.3.4"
   },
   "devDependencies": {
     "@types/node": "24.1.0",


### PR DESCRIPTION
## Summary
- install **swr** for data fetching
- configure a default fetcher and `SWRProvider`
- wrap app shell with the new provider
- allow TypeScript files in `lib/` to be tracked

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688be2f4cdc48326a9235e418e6cb7fb