### PR TITLE
Add dynamic panel registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -207,3 +207,4 @@ marimo/_lsp/
 __marimo__/
 node_modules/
 .next/
+!lib/

--- a/app/panels/AboutPanel.tsx
+++ b/app/panels/AboutPanel.tsx
@@ -1,0 +1,3 @@
+export default function AboutPanel() {
+  return <div>About Panel</div>;
+}

--- a/app/panels/HomePanel.tsx
+++ b/app/panels/HomePanel.tsx
@@ -1,0 +1,3 @@
+export default function HomePanel() {
+  return <div>Home Panel</div>;
+}

--- a/lib/panels.ts
+++ b/lib/panels.ts
@@ -1,0 +1,33 @@
+export interface PanelMetadata {
+  id: string;
+  title: string;
+  module: string;
+}
+
+// JSON schema describing the shape of a panel metadata object
+export const panelSchema = {
+  type: 'object',
+  properties: {
+    id: { type: 'string' },
+    title: { type: 'string' },
+    module: { type: 'string' },
+  },
+  required: ['id', 'title', 'module'],
+  additionalProperties: false,
+} as const;
+
+const registry: PanelMetadata[] = [
+  { id: 'home', title: 'Home Panel', module: '../app/panels/HomePanel' },
+  { id: 'about', title: 'About Panel', module: '../app/panels/AboutPanel' },
+];
+
+export type LoadedPanel = PanelMetadata & { Component: React.ComponentType<any> };
+
+export async function getPanels(): Promise<LoadedPanel[]> {
+  return Promise.all(
+    registry.map(async ({ module, ...meta }) => {
+      const mod = await import(module);
+      return { ...meta, Component: mod.default } as LoadedPanel;
+    })
+  );
+}


### PR DESCRIPTION
## Summary
- add a library to define panel metadata and dynamically load panel components
- add sample panels for Home and About
- unignore the `lib` directory

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688be2f44b8883269a730685196f9a78