### PR TITLE
Add basic NextAuth credentials route

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,37 @@
+import NextAuth, { type NextAuthOptions } from 'next-auth'
+import CredentialsProvider from 'next-auth/providers/credentials'
+
+export const authOptions: NextAuthOptions = {
+  providers: [
+    CredentialsProvider({
+      name: 'Credentials',
+      credentials: {
+        username: { label: 'Username', type: 'text', placeholder: 'admin' },
+        password: { label: 'Password', type: 'password' },
+      },
+      async authorize(credentials) {
+        if (!credentials) return null
+        const { username, password } = credentials
+        if (username === 'admin' && password === 'password') {
+          return { id: '1', name: 'Admin' }
+        }
+        return null
+      },
+    }),
+  ],
+  session: {
+    strategy: 'jwt',
+  },
+  callbacks: {
+    async session({ session, token }) {
+      if (session.user && token.sub) {
+        session.user.id = token.sub as string
+      }
+      return session
+    },
+  },
+}
+
+const handler = NextAuth(authOptions)
+export { handler as GET, handler as POST }
+export default authOptions

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -1,0 +1,10 @@
+import NextAuth, { DefaultSession } from 'next-auth'
+
+// Extend the default session type to include the user id
+declare module 'next-auth' {
+  interface Session {
+    user?: {
+      id: string
+    } & DefaultSession['user']
+  }
+}


### PR DESCRIPTION
## Summary
- implement NextAuth route with credentials provider
- enable JWT sessions and expose user id
- add TypeScript module augmentation for Session

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688be2f3d7d48326bcca1c4c2078d32e