### PR TITLE
Add settings page with theme selection

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,9 +1,10 @@
 import "./globals.css";
 import { SocketProvider } from "./socket-context";
-import { ReactNode, useState } from 'react';
+import { ReactNode } from 'react';
 import { SWRProvider } from '../lib/swr';
 import Link from 'next/link';
 import { SessionProvider, signIn, signOut, useSession } from 'next-auth/react';
+import { ThemeProvider, useTheme } from './theme-context';
 
 export const metadata = {
   title: 'Constellation Dashboard',
@@ -12,7 +13,9 @@ export const metadata = {
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
-      <Shell>{children}</Shell>
+      <ThemeProvider>
+        <Shell>{children}</Shell>
+      </ThemeProvider>
     </html>
   );
 }
@@ -20,8 +23,9 @@ export default function RootLayout({ children }: { children: ReactNode }) {
 function Shell({ children }: { children: ReactNode }) {
   'use client';
 
-  const [theme, setTheme] = useState<'light' | 'dark'>('light');
-  const toggleTheme = () => setTheme(t => (t === 'light' ? 'dark' : 'light'));
+  const { theme, setTheme } = useTheme();
+  const toggleTheme = () =>
+    setTheme(theme === 'cyber' ? 'pastel' : 'cyber');
 
   return (
     <SWRProvider>
@@ -40,16 +44,17 @@ function ShellContent({
   toggleTheme,
 }: {
   children: ReactNode;
-  theme: 'light' | 'dark';
+  theme: 'cyber' | 'pastel';
   toggleTheme: () => void;
 }) {
   const { data: session } = useSession();
 
   return (
     <SocketProvider>
-      <body className={theme}>
+      <body>
         <nav style={{ display: 'flex', gap: '1rem' }}>
           <Link href="/">Home</Link>
+          <Link href="/settings">Settings</Link>
           {session ? (
             <button type="button" onClick={() => signOut()}>Sign out</button>
           ) : (

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,0 +1,18 @@
+'use client';
+import { useTheme } from '../theme-context';
+
+export default function SettingsPage() {
+  const { theme, setTheme } = useTheme();
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+      <h1>Choose Theme</h1>
+      <div>
+        <button type="button" onClick={() => setTheme('cyber')}>Cyber</button>
+        <button type="button" onClick={() => setTheme('pastel')} style={{ marginLeft: '1rem' }}>
+          Pastel
+        </button>
+      </div>
+      <p>Current theme: {theme}</p>
+    </div>
+  );
+}

--- a/app/theme-context.tsx
+++ b/app/theme-context.tsx
@@ -1,0 +1,47 @@
+'use client';
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+export type Theme = 'cyber' | 'pastel';
+interface ThemeContextType {
+  theme: Theme;
+  setTheme: (t: Theme) => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>('cyber');
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const stored = localStorage.getItem('theme') as Theme | null;
+    if (stored) {
+      setThemeState(stored);
+      document.documentElement.dataset.theme = stored;
+    } else {
+      document.documentElement.dataset.theme = 'cyber';
+    }
+  }, []);
+
+  const setTheme = (t: Theme) => {
+    setThemeState(t);
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('theme', t);
+      document.documentElement.dataset.theme = t;
+    }
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within ThemeProvider');
+  }
+  return context;
+}


### PR DESCRIPTION
## Summary
- add a ThemeProvider to handle theme selection
- create a settings page with buttons for `cyber` and `pastel` themes
- persist theme choice in `localStorage` and apply via `data-theme`
- link settings in the main navigation

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688c04722f4c832697aa6fac624e2fda