### PR TITLE
Fix ShellContent props and import

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,6 @@
 import "./globals.css";
 import { SocketProvider } from "./socket-context";
-import { ReactNode } from 'react';
+import { ReactNode, useEffect } from 'react';
 
 import { SWRProvider } from '../lib/swr';
 import Link from 'next/link';
@@ -32,7 +32,7 @@ function Shell({ children }: { children: ReactNode }) {
   useEffect(() => {
     const stored = window.localStorage.getItem('theme') as 'light' | 'dark' | null;
     if (stored) setTheme(stored);
-  }, []);
+  }, [setTheme]);
 
   useEffect(() => {
     document.documentElement.dataset.theme = theme;
@@ -56,8 +56,6 @@ function ShellContent({
   toggleTheme,
 }: {
   children: ReactNode;
-  theme: 'cyber' | 'pastel';
-
   toggleTheme: () => void;
 }) {
   const { data: session } = useSession();


### PR DESCRIPTION
## Summary
- import `useEffect` from React
- remove unused `theme` prop from `ShellContent`
- fix ESLint warning by including `setTheme` in dependency array

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688cb629893c832682f85744cf81002b