### PR TITLE
Add calendar and finance panels

### DIFF
--- a/app/panels/CalendarPanel.tsx
+++ b/app/panels/CalendarPanel.tsx
@@ -1,0 +1,2 @@
+'use client'
+export { default } from '../calendar/page'

--- a/app/panels/FinancePanel.tsx
+++ b/app/panels/FinancePanel.tsx
@@ -1,0 +1,2 @@
+'use client'
+export { default } from '../finance/page'

--- a/app/panels/IdeasPanel.tsx
+++ b/app/panels/IdeasPanel.tsx
@@ -1,0 +1,2 @@
+'use client'
+export { default } from '../ideas/page'

--- a/app/panels/InvestPanel.tsx
+++ b/app/panels/InvestPanel.tsx
@@ -1,0 +1,2 @@
+'use client'
+export { default } from '../invest/page'

--- a/app/panels/SettingsPanel.tsx
+++ b/app/panels/SettingsPanel.tsx
@@ -1,0 +1,2 @@
+'use client'
+export { default } from '../settings/page'

--- a/lib/panels.ts
+++ b/lib/panels.ts
@@ -19,6 +19,11 @@ export const panelSchema = {
 const registry: PanelMetadata[] = [
   { id: 'home', title: 'Home Panel', module: '../app/panels/HomePanel' },
   { id: 'about', title: 'About Panel', module: '../app/panels/AboutPanel' },
+  { id: 'calendar', title: 'Calendar Panel', module: '../app/panels/CalendarPanel' },
+  { id: 'finance', title: 'Finance Panel', module: '../app/panels/FinancePanel' },
+  { id: 'invest', title: 'Invest Panel', module: '../app/panels/InvestPanel' },
+  { id: 'ideas', title: 'Ideas Panel', module: '../app/panels/IdeasPanel' },
+  { id: 'settings', title: 'Settings Panel', module: '../app/panels/SettingsPanel' },
 ];
 
 export type LoadedPanel = PanelMetadata & { Component: React.ComponentType<any> };


### PR DESCRIPTION
## Summary
- add new Calendar, Finance, Invest, Ideas and Settings panel components
- register metadata for the new panels

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688cb62a76ec83269ce960b889e02f7e