### PR TITLE
Add vitest tests for registry and API routes

### DIFF
--- a/tests/api-routes.test.ts
+++ b/tests/api-routes.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from 'vitest'
+
+// Helper to reload a module so that its internal state is reset between tests
+async function loadScheduleModule() {
+  vi.resetModules()
+  return await import('../app/api/schedule/route')
+}
+
+describe('schedule API routes', () => {
+  it('handles GET and POST', async () => {
+    const { GET, POST } = await loadScheduleModule()
+    let res = await GET()
+    let events = await res.json()
+    expect(events).toHaveLength(1)
+
+    const newEvent = { id: '2', title: 'Test', start: '2024-01-01' }
+    const req = new Request('http://test', {
+      method: 'POST',
+      body: JSON.stringify(newEvent),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    let postRes = await POST(req)
+    expect(await postRes.json()).toEqual({ success: true })
+
+    res = await GET()
+    events = await res.json()
+    expect(events).toHaveLength(2)
+    expect(events.find((e: any) => e.id === newEvent.id)).toMatchObject(newEvent)
+  })
+})
+
+describe('budget report API route', () => {
+  it('returns static budget data', async () => {
+    const { GET } = await import('../app/api/v1/report/budget/route')
+    const res = await GET()
+    const data = await res.json()
+    expect(data).toEqual([
+      { category: 'Rent', amount: 1000 },
+      { category: 'Food', amount: 300 },
+      { category: 'Utilities', amount: 150 },
+    ])
+  })
+})

--- a/tests/panel-registry.test.ts
+++ b/tests/panel-registry.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import { getPanels } from '../lib/panels'
+
+// Ensure that the panel registry loads all panels and provides a Component
+// for each entry.
+describe('panel registry', () => {
+  it('loads all configured panels', async () => {
+    const panels = await getPanels()
+    expect(panels).toHaveLength(7)
+    for (const panel of panels) {
+      expect(panel.id).toBeTruthy()
+      expect(panel.title).toBeTruthy()
+      expect(typeof panel.Component).toBe('function')
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- add tests for panel registry loading
- add tests for schedule and budget API routes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688cdc3b07a48326987b861789cce5e1