### PR TITLE
Add placeholder API routes

### DIFF
--- a/app/api/agent-feed/route.ts
+++ b/app/api/agent-feed/route.ts
@@ -1,0 +1,22 @@
+// Placeholder feed route using SSE instead of WebSocket
+
+export async function GET() {
+  const stream = new ReadableStream({
+    start(controller) {
+      const send = () => {
+        const data = JSON.stringify({ value: Math.random() })
+        controller.enqueue(`data: ${data}\n\n`)
+      }
+      send()
+      const interval = setInterval(send, 1000)
+      controller.onCancel = () => clearInterval(interval)
+    },
+  })
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+    },
+  })
+}

--- a/app/api/task/[id]/route.ts
+++ b/app/api/task/[id]/route.ts
@@ -1,0 +1,16 @@
+const tasks = [
+  { id: '1', name: 'Sample Task One', status: 'pending' },
+  { id: '2', name: 'Sample Task Two', status: 'completed' },
+]
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const task = tasks.find(t => t.id === params.id) ?? {
+    id: params.id,
+    name: `Mock Task ${params.id}`,
+    status: 'pending',
+  }
+  return Response.json(task)
+}


### PR DESCRIPTION
## Summary
- add placeholder GET `/api/task/[id]` route with mock data
- add stub agent feed at `/api/agent-feed` using SSE

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688cdc3a30b88326b09f43451703463b