### PR TITLE
Add socket provider and panel metadata tests

### DIFF
--- a/app/socket-context.tsx
+++ b/app/socket-context.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { createContext, useContext, useEffect, useState } from 'react';
+import React, { createContext, useContext, useEffect, useState } from 'react';
 
 const SocketContext = createContext<WebSocket | null>(null);
 

--- a/tests/panel-registry.test.ts
+++ b/tests/panel-registry.test.ts
@@ -13,4 +13,28 @@ describe('panel registry', () => {
       expect(typeof panel.Component).toBe('function')
     }
   })
+
+  it('returns metadata for each known panel', async () => {
+    const panels = await getPanels()
+    const ids = panels.map(p => p.id)
+    const titles = panels.map(p => p.title)
+    expect(ids).toEqual([
+      'home',
+      'about',
+      'calendar',
+      'finance',
+      'invest',
+      'idea-garden',
+      'settings',
+    ])
+    expect(titles).toEqual([
+      'Home Panel',
+      'About Panel',
+      'Calendar Panel',
+      'Finance Panel',
+      'Invest Panel',
+      'Idea Garden Panel',
+      'Settings Panel',
+    ])
+  })
 })

--- a/tests/socket-provider.test.tsx
+++ b/tests/socket-provider.test.tsx
@@ -1,0 +1,36 @@
+import React, { useEffect } from 'react';
+import ReactDOM from 'react-dom/client';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { SocketProvider, useSocket } from '../app/socket-context';
+import { act } from 'react-dom/test-utils';
+
+function render(ui: React.ReactElement) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = ReactDOM.createRoot(container);
+  act(() => {
+    root.render(ui);
+  });
+  return { container, root };
+}
+
+describe('SocketProvider', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('provides a WebSocket instance after initialization', async () => {
+    let socket: WebSocket | null = null;
+    function GetSocket() {
+      socket = useSocket();
+      return null;
+    }
+    render(
+      <SocketProvider>
+        <GetSocket />
+      </SocketProvider>
+    );
+    await act(async () => {});
+    expect(socket).toBeInstanceOf(WebSocket);
+  });
+});

--- a/tests/theme-provider.test.tsx
+++ b/tests/theme-provider.test.tsx
@@ -49,4 +49,29 @@ describe('ThemeProvider', () => {
     expect(localStorage.getItem('theme')).toBe('pastel');
     expect(document.documentElement.dataset.theme).toBe('pastel');
   });
+
+  it('persists theme across provider remounts', async () => {
+    function SetTheme() {
+      const { setTheme } = useTheme();
+      useEffect(() => {
+        setTheme('pastel');
+      }, [setTheme]);
+      return null;
+    }
+    const first = render(
+      <ThemeProvider>
+        <SetTheme />
+      </ThemeProvider>
+    );
+    await act(async () => {});
+    first.root.unmount();
+
+    render(
+      <ThemeProvider>
+        <div>test</div>
+      </ThemeProvider>
+    );
+    await act(async () => {});
+    expect(document.documentElement.dataset.theme).toBe('pastel');
+  });
 });


### PR DESCRIPTION
## Summary
- add missing React import in `SocketProvider`
- verify full panel metadata from `getPanels`
- add test ensuring theme persists across provider remounts
- add tests ensuring `SocketProvider` exposes a live WebSocket

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d2e1a33748326ad0b1ca5ae0c67d5