### PR TITLE
feat: add idea seed api

### DIFF
--- a/app/api/ume/idea-seeds/[id]/route.ts
+++ b/app/api/ume/idea-seeds/[id]/route.ts
@@ -1,0 +1,20 @@
+import { ideaSeeds } from '../data'
+
+export async function PUT(req: Request, { params }: { params: { id: string } }) {
+  const data = await req.json()
+  const seed = ideaSeeds.find(s => s.id === params.id)
+  if (!seed) {
+    return new Response('Not found', { status: 404 })
+  }
+  seed.text = data.text ?? seed.text
+  return Response.json({ success: true })
+}
+
+export async function DELETE(_req: Request, { params }: { params: { id: string } }) {
+  const idx = ideaSeeds.findIndex(s => s.id === params.id)
+  if (idx === -1) {
+    return new Response('Not found', { status: 404 })
+  }
+  ideaSeeds.splice(idx, 1)
+  return Response.json({ success: true })
+}

--- a/app/api/ume/idea-seeds/data.ts
+++ b/app/api/ume/idea-seeds/data.ts
@@ -1,0 +1,6 @@
+export interface IdeaSeed {
+  id: string
+  text: string
+}
+
+export let ideaSeeds: IdeaSeed[] = []

--- a/app/api/ume/idea-seeds/route.ts
+++ b/app/api/ume/idea-seeds/route.ts
@@ -1,0 +1,15 @@
+import { ideaSeeds, IdeaSeed } from './data'
+
+export async function GET() {
+  return Response.json(ideaSeeds)
+}
+
+export async function POST(req: Request) {
+  const data = await req.json()
+  const newSeed: IdeaSeed = {
+    id: Date.now().toString(),
+    text: data.text ?? ''
+  }
+  ideaSeeds.push(newSeed)
+  return Response.json(newSeed, { status: 201 })
+}

--- a/tests/ume-idea-seeds.test.ts
+++ b/tests/ume-idea-seeds.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi } from 'vitest'
+
+async function loadIdeaSeedModules() {
+  vi.resetModules()
+  const listHandlers = await import('../app/api/ume/idea-seeds/route')
+  const itemHandlers = await import('../app/api/ume/idea-seeds/[id]/route')
+  return { listHandlers, itemHandlers }
+}
+
+describe('ume idea seeds API', () => {
+  it('performs CRUD operations', async () => {
+    const { listHandlers: { GET, POST }, itemHandlers: { PUT, DELETE } } = await loadIdeaSeedModules()
+
+    // initial list should be empty
+    let res = await GET()
+    let seeds = await res.json()
+    expect(seeds).toHaveLength(0)
+
+    // create a seed
+    const createReq = new Request('http://test', {
+      method: 'POST',
+      body: JSON.stringify({ text: 'First idea' }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    const createRes = await POST(createReq)
+    const created = await createRes.json()
+    expect(created).toMatchObject({ text: 'First idea' })
+    const id = created.id
+
+    // ensure seed was added
+    res = await GET()
+    seeds = await res.json()
+    expect(seeds).toHaveLength(1)
+    expect(seeds[0]).toMatchObject({ id, text: 'First idea' })
+
+    // update the seed
+    const updateReq = new Request('http://test', {
+      method: 'PUT',
+      body: JSON.stringify({ text: 'Updated idea' }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    const updateRes = await PUT(updateReq, { params: { id } })
+    expect(await updateRes.json()).toEqual({ success: true })
+
+    res = await GET()
+    seeds = await res.json()
+    expect(seeds[0]).toMatchObject({ id, text: 'Updated idea' })
+
+    // delete the seed
+    const deleteRes = await DELETE(new Request('http://test'), { params: { id } })
+    expect(await deleteRes.json()).toEqual({ success: true })
+
+    res = await GET()
+    seeds = await res.json()
+    expect(seeds).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## Summary
- add REST handlers for UME idea seed CRUD
- cover idea seed API with unit tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e2b53710c83269868fb7007890ffd