### PR TITLE
feat: make WebSocket URL configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ The app will be available at `http://localhost:3000`.
 - Run `npm run lint` to check code style.
 - Run `npm run test` to execute unit tests with Vitest.
 
+## Environment Variables
+
+- `NEXT_PUBLIC_WS_URL` &ndash; WebSocket server URL used by the dashboard. Defaults to `ws://localhost:3001` if not provided.
+
 ## Adding New Panels
 
 1. Create a React component in `app/panels/`.

--- a/app/socket-context.tsx
+++ b/app/socket-context.tsx
@@ -12,7 +12,8 @@ export function SocketProvider({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
-    const ws = new WebSocket('ws://localhost:3001');
+    const url = process.env.NEXT_PUBLIC_WS_URL ?? 'ws://localhost:3001';
+    const ws = new WebSocket(url);
     setSocket(ws);
     return () => ws.close();
   }, []);

--- a/tests/socket-provider.test.tsx
+++ b/tests/socket-provider.test.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { SocketProvider, useSocket } from '../app/socket-context';
 import { act } from 'react-dom/test-utils';
 
@@ -15,22 +15,38 @@ function render(ui: React.ReactElement) {
 }
 
 describe('SocketProvider', () => {
+  const originalEnv = process.env.NEXT_PUBLIC_WS_URL;
+
   beforeEach(() => {
     document.body.innerHTML = '';
+    process.env.NEXT_PUBLIC_WS_URL = 'ws://example.test';
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    process.env.NEXT_PUBLIC_WS_URL = originalEnv;
   });
 
   it('provides a WebSocket instance after initialization', async () => {
+    const wsInstance = { close: vi.fn() } as unknown as WebSocket;
+    const wsMock = vi.fn(() => wsInstance);
+    vi.stubGlobal('WebSocket', wsMock);
+
     let socket: WebSocket | null = null;
     function GetSocket() {
       socket = useSocket();
       return null;
     }
+
     render(
       <SocketProvider>
         <GetSocket />
       </SocketProvider>
     );
+
     await act(async () => {});
-    expect(socket).toBeInstanceOf(WebSocket);
+
+    expect(wsMock).toHaveBeenCalledWith('ws://example.test');
+    expect(socket).toBe(wsInstance);
   });
 });


### PR DESCRIPTION
## Summary
- allow configuring WebSocket URL via `NEXT_PUBLIC_WS_URL` with a fallback default
- stub environment variable in socket provider tests
- document `NEXT_PUBLIC_WS_URL`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e2b5449cc832682272102c63e0749