### PR TITLE
feat: allow scheduling events

### DIFF
--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import React, { useState } from 'react'
 import FullCalendar from '@fullcalendar/react'
 import dayGridPlugin from '@fullcalendar/daygrid'
 import interactionPlugin, { EventDropArg } from '@fullcalendar/interaction'
@@ -8,23 +9,81 @@ import { fetcher } from '../../lib/swr'
 
 export default function CalendarPage() {
   const { data: events = [], mutate } = useSWR('/api/schedule', fetcher)
+  const [title, setTitle] = useState('')
+  const [start, setStart] = useState('')
+  const [end, setEnd] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    const res = await fetch('/api/schedule', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title, start, end })
+    })
+    if (!res.ok) {
+      setError('Failed to create event')
+      return
+    }
+    setTitle('')
+    setStart('')
+    setEnd('')
+    mutate()
+  }
 
   const handleDrop = async (arg: EventDropArg) => {
-    await fetch(`/api/task/${arg.event.id}`, {
+    setError(null)
+    const res = await fetch(`/api/task/${arg.event.id}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ start: arg.event.startStr, end: arg.event.endStr })
     })
+    if (!res.ok) {
+      setError('Failed to update event')
+    }
     mutate()
   }
 
   return (
-    <FullCalendar
-      plugins={[dayGridPlugin, interactionPlugin]}
-      initialView="dayGridMonth"
-      events={events}
-      editable
-      eventDrop={handleDrop}
-    />
+    <div>
+      <form onSubmit={handleCreate} className="mb-4">
+        <input
+          name="title"
+          placeholder="Title"
+          value={title}
+          onChange={e => setTitle(e.target.value)}
+          className="border mr-2"
+        />
+        <input
+          name="start"
+          type="date"
+          value={start}
+          onChange={e => setStart(e.target.value)}
+          className="border mr-2"
+        />
+        <input
+          name="end"
+          type="date"
+          value={end}
+          onChange={e => setEnd(e.target.value)}
+          className="border mr-2"
+        />
+        <button type="submit" className="border px-2">Add</button>
+      </form>
+      {error && <p role="alert" className="text-red-500">{error}</p>}
+      <ul>
+        {events.map((e: any) => (
+          <li key={e.id}>{e.title}</li>
+        ))}
+      </ul>
+      <FullCalendar
+        plugins={[dayGridPlugin, interactionPlugin]}
+        initialView="dayGridMonth"
+        events={events}
+        editable
+        eventDrop={handleDrop}
+      />
+    </div>
   )
 }

--- a/tests/calendar-page.test.tsx
+++ b/tests/calendar-page.test.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act } from 'react-dom/test-utils';
+
+// mocks
+let swrMock: any;
+let calendarProps: any;
+vi.mock('swr', () => ({
+  __esModule: true,
+  default: (...args: any[]) => swrMock(...args)
+}));
+vi.mock('@fullcalendar/react', () => ({
+  __esModule: true,
+  default: (props: any) => {
+    calendarProps = props;
+    return React.createElement('div');
+  }
+}));
+
+import CalendarPage from '../app/calendar/page';
+
+function render(ui: React.ReactElement) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = ReactDOM.createRoot(container);
+  act(() => {
+    root.render(ui);
+  });
+  return { container, root };
+}
+
+describe('CalendarPage', () => {
+  beforeEach(() => {
+    calendarProps = {};
+    document.body.innerHTML = '';
+    vi.unstubAllGlobals();
+  });
+
+  it('creates an event via the form', async () => {
+    const mutate = vi.fn();
+    swrMock = vi.fn(() => ({ data: [], mutate }));
+    const fetchMock = vi.fn(() => Promise.resolve({ ok: true, json: async () => ({}) }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { container } = render(<CalendarPage />);
+
+    const title = container.querySelector('input[name="title"]') as HTMLInputElement;
+    const start = container.querySelector('input[name="start"]') as HTMLInputElement;
+    const end = container.querySelector('input[name="end"]') as HTMLInputElement;
+    const form = container.querySelector('form') as HTMLFormElement;
+
+    act(() => {
+      title.value = 'test';
+      title.dispatchEvent(new Event('input', { bubbles: true }));
+      start.value = '2024-01-01';
+      start.dispatchEvent(new Event('input', { bubbles: true }));
+      end.value = '2024-01-02';
+      end.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+
+    await act(async () => {
+      form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/schedule', expect.objectContaining({ method: 'POST' }));
+    expect(mutate).toHaveBeenCalled();
+  });
+
+  it('updates an event on drop', async () => {
+    const mutate = vi.fn();
+    swrMock = vi.fn(() => ({ data: [{ id: '1', title: 'a' }], mutate }));
+    const fetchMock = vi.fn(() => Promise.resolve({ ok: true }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<CalendarPage />);
+
+    await act(async () => {
+      await calendarProps.eventDrop({
+        event: { id: '1', startStr: '2024-01-03', endStr: '2024-01-04' }
+      });
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/task/1', expect.anything());
+    expect(mutate).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add inline calendar event form
- render event titles with error feedback
- test create and edit flows

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e2ea85f308326bf3b01cfb356e6ba