### PR TITLE
refactor: extract shared schedule calendar

### DIFF
--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -1,18 +1,14 @@
 'use client'
 
 import React, { useState } from 'react'
-import FullCalendar from '@fullcalendar/react'
-import dayGridPlugin from '@fullcalendar/daygrid'
-import interactionPlugin, { EventDropArg } from '@fullcalendar/interaction'
-import useSWR from 'swr'
-import { fetcher } from '../../lib/swr'
+import ScheduleCalendar from '../components/ScheduleCalendar'
 
 export default function CalendarPage() {
-  const { data: events = [], mutate } = useSWR('/api/schedule', fetcher)
   const [title, setTitle] = useState('')
   const [start, setStart] = useState('')
   const [end, setEnd] = useState('')
   const [error, setError] = useState<string | null>(null)
+  const [mutate, setMutate] = useState<(() => void) | null>(null)
 
   const handleCreate = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -29,20 +25,7 @@ export default function CalendarPage() {
     setTitle('')
     setStart('')
     setEnd('')
-    mutate()
-  }
-
-  const handleDrop = async (arg: EventDropArg) => {
-    setError(null)
-    const res = await fetch(`/api/task/${arg.event.id}`, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ start: arg.event.startStr, end: arg.event.endStr })
-    })
-    if (!res.ok) {
-      setError('Failed to update event')
-    }
-    mutate()
+    mutate?.()
   }
 
   return (
@@ -72,18 +55,7 @@ export default function CalendarPage() {
         <button type="submit" className="border px-2">Add</button>
       </form>
       {error && <p role="alert" className="text-red-500">{error}</p>}
-      <ul>
-        {events.map((e: any) => (
-          <li key={e.id}>{e.title}</li>
-        ))}
-      </ul>
-      <FullCalendar
-        plugins={[dayGridPlugin, interactionPlugin]}
-        initialView="dayGridMonth"
-        events={events}
-        editable
-        eventDrop={handleDrop}
-      />
+      <ScheduleCalendar onMutate={setMutate} />
     </div>
   )
 }

--- a/app/panels/CalendarPanel.tsx
+++ b/app/panels/CalendarPanel.tsx
@@ -1,30 +1,8 @@
 'use client'
 
-import FullCalendar from '@fullcalendar/react'
-import dayGridPlugin from '@fullcalendar/daygrid'
-import interactionPlugin, { EventDropArg } from '@fullcalendar/interaction'
-import useSWR from 'swr'
-import { fetcher } from '../../lib/swr'
+import ScheduleCalendar from '../components/ScheduleCalendar'
 
 export default function CalendarPanel() {
-  const { data: events = [], mutate } = useSWR('/api/schedule', fetcher)
-
-  const handleDrop = async (arg: EventDropArg) => {
-    await fetch('/api/schedule', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ id: arg.event.id, start: arg.event.startStr, end: arg.event.endStr })
-    })
-    mutate()
-  }
-
-  return (
-    <FullCalendar
-      plugins={[dayGridPlugin, interactionPlugin]}
-      initialView="dayGridMonth"
-      events={events}
-      editable
-      eventDrop={handleDrop}
-    />
-  )
+  return <ScheduleCalendar />
 }
+


### PR DESCRIPTION
## Summary
- add shared `ScheduleCalendar` component for rendering calendar events
- refactor calendar page to use new component
- simplify calendar panel by reusing shared calendar

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688ea13128d483268938fd4f4b7cf3ac