### PR TITLE
Protect schedule and task APIs with session checks

### DIFF
--- a/app/api/schedule/route.ts
+++ b/app/api/schedule/route.ts
@@ -1,11 +1,22 @@
 import { getEvents, addEvent, validateEvent } from './store'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '../auth/[...nextauth]/route'
 
 export async function GET() {
+  const session = await getServerSession(authOptions)
+  if (!session) {
+    return new Response('Unauthorized', { status: 401 })
+  }
   const events = await getEvents()
   return Response.json(events)
 }
 
 export async function POST(req: Request) {
+  const session = await getServerSession(authOptions)
+  if (!session) {
+    return new Response('Unauthorized', { status: 401 })
+  }
+
   let body: unknown
   try {
     body = await req.json()

--- a/app/api/task/[id]/route.ts
+++ b/app/api/task/[id]/route.ts
@@ -1,9 +1,15 @@
 import { getEvent, updateEvent, validateEventPatch } from '../../schedule/store'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '../../auth/[...nextauth]/route'
 
 export async function GET(
   _req: Request,
   { params }: { params: { id: string } },
 ) {
+  const session = await getServerSession(authOptions)
+  if (!session) {
+    return new Response('Unauthorized', { status: 401 })
+  }
   const event = await getEvent(params.id)
   if (!event) {
     return new Response('Not found', { status: 404 })
@@ -15,6 +21,10 @@ export async function PATCH(
   req: Request,
   { params }: { params: { id: string } },
 ) {
+  const session = await getServerSession(authOptions)
+  if (!session) {
+    return new Response('Unauthorized', { status: 401 })
+  }
   let body: unknown
   try {
     body = await req.json()


### PR DESCRIPTION
## Summary
- add getServerSession checks to schedule GET and POST handlers
- add session validation to task GET and PATCH routes
- mock sessions in tests and cover unauthorized access

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688eacb3cb408326b22f5a044c8ae167