### PR TITLE
feat: add calendar layers and nl command support

### DIFF
--- a/app/api/schedule/route.ts
+++ b/app/api/schedule/route.ts
@@ -1,4 +1,4 @@
-import { getEvents, addEvent, validateEvent } from './store'
+import { getData, addEvent, validateEvent } from './store'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '../auth/[...nextauth]/route'
 
@@ -7,8 +7,8 @@ export async function GET() {
   if (!session) {
     return new Response('Unauthorized', { status: 401 })
   }
-  const events = await getEvents()
-  return Response.json(events)
+  const data = await getData()
+  return Response.json(data)
 }
 
 export async function POST(req: Request) {

--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -1,22 +1,62 @@
 'use client'
 
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
+import useSWR from 'swr'
+import { fetcher } from '../../lib/swr'
 import ScheduleCalendar from '../components/ScheduleCalendar'
+import CalendarLayerPanel from '../components/CalendarLayerPanel'
+import { useSocket } from '../socket-context'
+
+interface Layer {
+  id: string
+  name: string
+  color: string
+}
+
+interface Event {
+  id: string
+  title?: string
+  start: string
+  end?: string
+  layer?: string
+  shared?: boolean
+}
+
+interface CalendarData {
+  events: Event[]
+  layers: Layer[]
+}
 
 export default function CalendarPage() {
+  const { data = { events: [], layers: [] } as CalendarData, mutate } = useSWR<CalendarData>('/api/schedule', fetcher)
   const [title, setTitle] = useState('')
   const [start, setStart] = useState('')
   const [end, setEnd] = useState('')
   const [error, setError] = useState<string | null>(null)
-  const [mutate, setMutate] = useState<(() => void) | null>(null)
+  const [selectedLayers, setSelectedLayers] = useState<string[]>([])
+
+  const socket = useSocket()
+  const [nl, setNl] = useState('')
+
+  useEffect(() => {
+    setSelectedLayers(data.layers.map(l => l.id))
+  }, [data.layers])
+
+  const handleNL = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!nl) return
+    socket?.send(JSON.stringify({ type: 'calendar.nl.request', text: nl }))
+    setNl('')
+  }
 
   const handleCreate = async (e: React.FormEvent) => {
     e.preventDefault()
     setError(null)
+    const layer = selectedLayers[0]
     const res = await fetch('/api/schedule', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ title, start, end })
+      body: JSON.stringify({ title, start, end, layer })
     })
     if (!res.ok) {
       setError('Failed to create event')
@@ -25,11 +65,27 @@ export default function CalendarPage() {
     setTitle('')
     setStart('')
     setEnd('')
-    mutate?.()
+    mutate()
+  }
+
+  const toggleLayer = (id: string) => {
+    setSelectedLayers(prev =>
+      prev.includes(id) ? prev.filter(l => l !== id) : [...prev, id]
+    )
   }
 
   return (
     <div>
+      <form onSubmit={handleNL} className="mb-4">
+        <input
+          name="nl"
+          value={nl}
+          onChange={e => setNl(e.target.value)}
+          className="border mr-2"
+        />
+        <button type="submit" className="border px-2">Send</button>
+      </form>
+      <CalendarLayerPanel layers={data.layers} selected={selectedLayers} onToggle={toggleLayer} />
       <form onSubmit={handleCreate} className="mb-4">
         <input
           name="title"
@@ -55,7 +111,12 @@ export default function CalendarPage() {
         <button type="submit" className="border px-2">Add</button>
       </form>
       {error && <p role="alert" className="text-red-500">{error}</p>}
-      <ScheduleCalendar onMutate={setMutate} />
+      <ScheduleCalendar
+        events={data.events}
+        layers={data.layers}
+        visibleLayers={selectedLayers}
+        mutate={mutate}
+      />
     </div>
   )
 }

--- a/app/components/CalendarLayerPanel.tsx
+++ b/app/components/CalendarLayerPanel.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import React from 'react'
+
+interface Layer {
+  id: string
+  name: string
+  color: string
+}
+
+interface CalendarLayerPanelProps {
+  layers: Layer[]
+  selected: string[]
+  onToggle: (id: string) => void
+}
+
+export default function CalendarLayerPanel({ layers, selected, onToggle }: CalendarLayerPanelProps) {
+  return (
+    <div className="mb-4">
+      {layers.map(layer => (
+        <label key={layer.id} className="flex items-center space-x-2 mb-1">
+          <input
+            type="checkbox"
+            checked={selected.includes(layer.id)}
+            onChange={() => onToggle(layer.id)}
+          />
+          <span className="w-3 h-3 inline-block" style={{ backgroundColor: layer.color }} />
+          <span>{layer.name}</span>
+        </label>
+      ))}
+    </div>
+  )
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@fullcalendar/daygrid": "^6.1.18",
         "@fullcalendar/interaction": "^6.1.18",
         "@fullcalendar/react": "^6.1.18",
+        "@fullcalendar/timegrid": "^6.1.18",
         "next": "^15.4.5",
         "next-auth": "^4.24.11",
         "react": "^19.1.1",
@@ -856,6 +857,18 @@
         "@fullcalendar/core": "~6.1.18",
         "react": "^16.7.0 || ^17 || ^18 || ^19",
         "react-dom": "^16.7.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/@fullcalendar/timegrid": {
+      "version": "6.1.18",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/timegrid/-/timegrid-6.1.18.tgz",
+      "integrity": "sha512-T/ouhs+T1tM8JcW7Cjx+KiohL/qQWKqvRITwjol8ktJ1e1N/6noC40/obR1tyolqOxMRWHjJkYoj9fUqfoez9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@fullcalendar/daygrid": "~6.1.18"
+      },
+      "peerDependencies": {
+        "@fullcalendar/core": "~6.1.18"
       }
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@fullcalendar/daygrid": "^6.1.18",
     "@fullcalendar/interaction": "^6.1.18",
+    "@fullcalendar/timegrid": "^6.1.18",
     "@fullcalendar/react": "^6.1.18",
     "next": "^15.4.5",
     "next-auth": "^4.24.11",

--- a/tests/api-routes.test.ts
+++ b/tests/api-routes.test.ts
@@ -33,7 +33,7 @@ describe('schedule API routes', () => {
     process.env.SCHEDULE_DATA_FILE = file
     await fs.writeFile(
       file,
-      JSON.stringify([{ id: '1', title: 'Sample Event', start: '2024-01-01' }]),
+      JSON.stringify({ events: [{ id: '1', title: 'Sample Event', start: '2024-01-01' }], layers: [] }),
     )
 
     vi.mocked(getServerSession).mockResolvedValue({ user: { id: '1' } })
@@ -42,8 +42,8 @@ describe('schedule API routes', () => {
       schedule: { GET, POST },
     } = await loadScheduleModules()
     let res = await GET()
-    let events = await res.json()
-    expect(events).toHaveLength(1)
+    let data = await res.json()
+    expect(data.events).toHaveLength(1)
 
     const newEvent = { id: '2', title: 'Test', start: '2024-01-01' }
     const req = new Request('http://test', {
@@ -55,14 +55,14 @@ describe('schedule API routes', () => {
     expect(await postRes.json()).toEqual({ success: true })
 
     res = await GET()
-    events = await res.json()
-    expect(events).toHaveLength(2)
-    expect(events.find((e: any) => e.id === newEvent.id)).toMatchObject(newEvent)
+    data = await res.json()
+    expect(data.events).toHaveLength(2)
+    expect(data.events.find((e: any) => e.id === newEvent.id)).toMatchObject(newEvent)
   })
 
   it('handles PATCH via task API', async () => {
     process.env.SCHEDULE_DATA_FILE = file
-    await fs.writeFile(file, '[]')
+    await fs.writeFile(file, JSON.stringify({ events: [], layers: [] }))
 
     vi.mocked(getServerSession).mockResolvedValue({ user: { id: '1' } })
 
@@ -87,15 +87,15 @@ describe('schedule API routes', () => {
     expect(await patchRes.json()).toEqual({ success: true })
 
     const res = await GET()
-    const events = await res.json()
-    expect(events.find((e: any) => e.id === newEvent.id)).toMatchObject({
+    const data = await res.json()
+    expect(data.events.find((e: any) => e.id === newEvent.id)).toMatchObject({
       start: '2024-06-01',
     })
   })
 
   it('returns 401 when unauthenticated', async () => {
     process.env.SCHEDULE_DATA_FILE = file
-    await fs.writeFile(file, '[]')
+    await fs.writeFile(file, JSON.stringify({ events: [], layers: [] }))
 
     vi.mocked(getServerSession).mockResolvedValue(null)
 


### PR DESCRIPTION
## Summary
- add day, week, and month views with layer-based colors in ScheduleCalendar
- introduce CalendarLayerPanel with visibility toggles and NL request form on calendar page
- persist layer metadata and shared flags in schedule store and API

## Testing
- `NODE_OPTIONS=--max-old-space-size=4096 npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688eb2e65a248326b5ceaf935a089641