### PR TITLE
feat: add context switcher and scoped APIs

### DIFF
--- a/app/api/schedule/route.ts
+++ b/app/api/schedule/route.ts
@@ -1,14 +1,19 @@
 import { getData, addEvent, validateEvent } from './store'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '../auth/[...nextauth]/route'
+import { getRequestContext } from '../../../lib/context'
 
-export async function GET() {
+export async function GET(req: Request) {
   const session = await getServerSession(authOptions)
   if (!session) {
     return new Response('Unauthorized', { status: 401 })
   }
+  const ctx = getRequestContext(req)
   const data = await getData()
-  return Response.json(data)
+  const events = data.events.filter(e =>
+    ctx === 'group' ? e.shared : !e.shared,
+  )
+  return Response.json({ events, layers: data.layers })
 }
 
 export async function POST(req: Request) {
@@ -16,6 +21,7 @@ export async function POST(req: Request) {
   if (!session) {
     return new Response('Unauthorized', { status: 401 })
   }
+  const ctx = getRequestContext(req)
 
   let body: unknown
   try {
@@ -25,6 +31,12 @@ export async function POST(req: Request) {
   }
   try {
     const event = validateEvent(body)
+    if (ctx === 'personal' && event.shared) {
+      return new Response('Forbidden', { status: 403 })
+    }
+    if (ctx === 'group' && !event.shared) {
+      return new Response('Forbidden', { status: 403 })
+    }
     await addEvent(event)
     return Response.json({ success: true })
   } catch (e: any) {

--- a/app/api/v1/report/budget/history/route.ts
+++ b/app/api/v1/report/budget/history/route.ts
@@ -1,9 +1,15 @@
 import { NextResponse } from 'next/server'
+import { getRequestContext } from '../../../../../../lib/context'
 
-export async function GET() {
-  const data = [
+export async function GET(req: Request) {
+  const ctx = getRequestContext(req)
+  const personal = [
     { id: '1', date: '2024-01-01', totalCost: 1200 },
     { id: '2', date: '2024-02-01', totalCost: 1300 },
   ]
-  return NextResponse.json(data)
+  const group = [
+    { id: 'g1', date: '2024-01-01', totalCost: 5000 },
+    { id: 'g2', date: '2024-02-01', totalCost: 5200 },
+  ]
+  return NextResponse.json(ctx === 'group' ? group : personal)
 }

--- a/app/api/v1/report/budget/route.ts
+++ b/app/api/v1/report/budget/route.ts
@@ -1,10 +1,17 @@
 import { NextResponse } from 'next/server'
+import { getRequestContext } from '../../../../../lib/context'
 
-export async function GET() {
-  const data = [
+export async function GET(req: Request) {
+  const ctx = getRequestContext(req)
+  const personal = [
     { category: 'Rent', amount: 1000 },
     { category: 'Food', amount: 300 },
     { category: 'Utilities', amount: 150 },
   ]
-  return NextResponse.json(data)
+  const group = [
+    { category: 'Office Rent', amount: 2000 },
+    { category: 'Team Meals', amount: 800 },
+    { category: 'Shared Utilities', amount: 400 },
+  ]
+  return NextResponse.json(ctx === 'group' ? group : personal)
 }

--- a/app/components/ContextSwitcher.tsx
+++ b/app/components/ContextSwitcher.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { useSession } from 'next-auth/react'
+import { useEffect, useState } from 'react'
+
+type ContextType = 'personal' | 'group'
+
+export default function ContextSwitcher() {
+  const { data: session } = useSession()
+  const [context, setContext] = useState<ContextType>('personal')
+
+  useEffect(() => {
+    const match = document.cookie.match(/(?:^|; )context=(personal|group)/)
+    if (match) {
+      setContext(match[1] as ContextType)
+    }
+  }, [])
+
+  const update = (value: ContextType) => {
+    setContext(value)
+    document.cookie = `context=${value}; path=/`
+  }
+
+  if (!session) return null
+
+  return (
+    <select value={context} onChange={e => update(e.target.value as ContextType)}>
+      <option value="personal">Personal</option>
+      <option value="group">Group</option>
+    </select>
+  )
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import { SWRProvider } from '../lib/swr';
 import Link from 'next/link';
 import { SessionProvider, signIn, signOut, useSession } from 'next-auth/react';
 import { ThemeProvider, useTheme } from './theme-context';
+import ContextSwitcher from './components/ContextSwitcher';
 
 export const metadata = {
   title: 'Constellation Dashboard',
@@ -59,6 +60,7 @@ function ShellContent({
           ) : (
             <button type="button" onClick={() => signIn()}>Sign in</button>
           )}
+          <ContextSwitcher />
           <button type="button" onClick={toggleTheme}>Toggle Theme</button>
         </nav>
         {children}

--- a/lib/context.ts
+++ b/lib/context.ts
@@ -1,0 +1,7 @@
+export type AppContext = 'personal' | 'group'
+
+export function getRequestContext(req: Request): AppContext {
+  const cookie = req.headers.get('cookie') || ''
+  const match = cookie.match(/(?:^|; )context=(personal|group)/)
+  return (match ? match[1] : 'personal') as AppContext
+}

--- a/tests/api-routes.test.ts
+++ b/tests/api-routes.test.ts
@@ -33,7 +33,10 @@ describe('schedule API routes', () => {
     process.env.SCHEDULE_DATA_FILE = file
     await fs.writeFile(
       file,
-      JSON.stringify({ events: [{ id: '1', title: 'Sample Event', start: '2024-01-01' }], layers: [] }),
+      JSON.stringify({
+        events: [{ id: '1', title: 'Sample Event', start: '2024-01-01', shared: false }],
+        layers: [],
+      }),
     )
 
     vi.mocked(getServerSession).mockResolvedValue({ user: { id: '1' } })
@@ -41,20 +44,20 @@ describe('schedule API routes', () => {
     const {
       schedule: { GET, POST },
     } = await loadScheduleModules()
-    let res = await GET()
+    let res = await GET(new Request('http://test', { headers: { cookie: 'context=personal' } }))
     let data = await res.json()
     expect(data.events).toHaveLength(1)
 
-    const newEvent = { id: '2', title: 'Test', start: '2024-01-01' }
+    const newEvent = { id: '2', title: 'Test', start: '2024-01-01', shared: false }
     const req = new Request('http://test', {
       method: 'POST',
       body: JSON.stringify(newEvent),
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', cookie: 'context=personal' },
     })
     const postRes = await POST(req)
     expect(await postRes.json()).toEqual({ success: true })
 
-    res = await GET()
+    res = await GET(new Request('http://test', { headers: { cookie: 'context=personal' } }))
     data = await res.json()
     expect(data.events).toHaveLength(2)
     expect(data.events.find((e: any) => e.id === newEvent.id)).toMatchObject(newEvent)
@@ -70,23 +73,23 @@ describe('schedule API routes', () => {
       schedule: { POST, GET },
       task: { PATCH },
     } = await loadScheduleModules()
-    const newEvent = { id: '3', title: 'Patch Test', start: '2024-05-01' }
+    const newEvent = { id: '3', title: 'Patch Test', start: '2024-05-01', shared: false }
     const req = new Request('http://test', {
       method: 'POST',
       body: JSON.stringify(newEvent),
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', cookie: 'context=personal' },
     })
     await POST(req)
 
     const patchReq = new Request('http://test', {
       method: 'PATCH',
       body: JSON.stringify({ start: '2024-06-01' }),
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', cookie: 'context=personal' },
     })
     const patchRes = await PATCH(patchReq, { params: { id: newEvent.id } })
     expect(await patchRes.json()).toEqual({ success: true })
 
-    const res = await GET()
+    const res = await GET(new Request('http://test', { headers: { cookie: 'context=personal' } }))
     const data = await res.json()
     expect(data.events.find((e: any) => e.id === newEvent.id)).toMatchObject({
       start: '2024-06-01',
@@ -102,20 +105,67 @@ describe('schedule API routes', () => {
     const {
       schedule: { GET },
     } = await loadScheduleModules()
-    const res = await GET()
+    const res = await GET(new Request('http://test', { headers: { cookie: 'context=personal' } }))
     expect(res.status).toBe(401)
+  })
+
+  it('enforces context isolation and permissions', async () => {
+    process.env.SCHEDULE_DATA_FILE = file
+    await fs.writeFile(
+      file,
+      JSON.stringify({
+        events: [
+          { id: '1', start: '2024-01-01', shared: false },
+          { id: '2', start: '2024-01-02', shared: true },
+        ],
+        layers: [],
+      }),
+    )
+
+    vi.mocked(getServerSession).mockResolvedValue({ user: { id: '1' } })
+    const {
+      schedule: { GET, POST },
+    } = await loadScheduleModules()
+
+    const resPersonal = await GET(
+      new Request('http://test', { headers: { cookie: 'context=personal' } }),
+    )
+    const dataPersonal = await resPersonal.json()
+    expect(dataPersonal.events).toHaveLength(1)
+
+    const resGroup = await GET(
+      new Request('http://test', { headers: { cookie: 'context=group' } }),
+    )
+    const dataGroup = await resGroup.json()
+    expect(dataGroup.events).toHaveLength(1)
+
+    const badReq = new Request('http://test', {
+      method: 'POST',
+      body: JSON.stringify({ id: '3', start: '2024-03-01', shared: true }),
+      headers: { 'Content-Type': 'application/json', cookie: 'context=personal' },
+    })
+    const badRes = await POST(badReq)
+    expect(badRes.status).toBe(403)
   })
 })
 
 describe('budget report API route', () => {
-  it('returns static budget data', async () => {
+  it('returns personal and group budget data based on context', async () => {
     const { GET } = await import('../app/api/v1/report/budget/route')
-    const res = await GET()
-    const data = await res.json()
-    expect(data).toEqual([
+    const resPersonal = await GET(new Request('http://test', { headers: { cookie: 'context=personal' } }))
+    const dataPersonal = await resPersonal.json()
+    expect(dataPersonal).toEqual([
       { category: 'Rent', amount: 1000 },
       { category: 'Food', amount: 300 },
       { category: 'Utilities', amount: 150 },
+    ])
+
+    const resGroup = await GET(new Request('http://test', { headers: { cookie: 'context=group' } }))
+    const dataGroup = await resGroup.json()
+    expect(dataGroup).toEqual([
+      { category: 'Office Rent', amount: 2000 },
+      { category: 'Team Meals', amount: 800 },
+      { category: 'Shared Utilities', amount: 400 },
     ])
   })
 })

--- a/tests/history.api.test.ts
+++ b/tests/history.api.test.ts
@@ -1,13 +1,20 @@
 import { describe, it, expect } from 'vitest'
 
 describe('budget history API route', () => {
-  it('returns past analyses', async () => {
+  it('returns history scoped to context', async () => {
     const { GET } = await import('../app/api/v1/report/budget/history/route')
-    const res = await GET()
-    const data = await res.json()
-    expect(data).toEqual([
+    const resPersonal = await GET(new Request('http://test', { headers: { cookie: 'context=personal' } }))
+    const dataPersonal = await resPersonal.json()
+    expect(dataPersonal).toEqual([
       { id: '1', date: '2024-01-01', totalCost: 1200 },
       { id: '2', date: '2024-02-01', totalCost: 1300 },
+    ])
+
+    const resGroup = await GET(new Request('http://test', { headers: { cookie: 'context=group' } }))
+    const dataGroup = await resGroup.json()
+    expect(dataGroup).toEqual([
+      { id: 'g1', date: '2024-01-01', totalCost: 5000 },
+      { id: 'g2', date: '2024-02-01', totalCost: 5200 },
     ])
   })
 })


### PR DESCRIPTION
## Summary
- add ContextSwitcher component with cookie-based selection between personal and group modes
- apply context to layout navigation and API routes, enforcing 403 on cross-context edits
- test context isolation and permission handling across schedule and report APIs

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ebb46208c832698f331bc0b4e00c5