### PR TITLE
feat: add caching and task status service

### DIFF
--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -28,7 +28,11 @@ interface CalendarData {
 }
 
 export default function CalendarPage() {
-  const { data = { events: [], layers: [] } as CalendarData, mutate } = useSWR<CalendarData>('/api/schedule', fetcher)
+  const { data = { events: [], layers: [] } as CalendarData, mutate } = useSWR<CalendarData>(
+    '/api/schedule',
+    fetcher,
+    { refreshInterval: 30000 },
+  )
   const [title, setTitle] = useState('')
   const [start, setStart] = useState('')
   const [end, setEnd] = useState('')

--- a/app/components/IdeaSeedList.tsx
+++ b/app/components/IdeaSeedList.tsx
@@ -10,7 +10,11 @@ type IdeaSeed = {
 }
 
 export default function IdeaSeedList() {
-  const { data: ideaSeeds = [], mutate } = useSWR<IdeaSeed[]>('/api/ume/idea-seeds', fetcher)
+  const { data: ideaSeeds = [], mutate } = useSWR<IdeaSeed[]>(
+    '/api/ume/idea-seeds',
+    fetcher,
+    { refreshInterval: 30000 },
+  )
   const [newIdeaText, setNewIdeaText] = useState('')
 
   const createIdea = async () => {

--- a/app/finance/history.tsx
+++ b/app/finance/history.tsx
@@ -11,7 +11,11 @@ type HistoryItem = {
 }
 
 export default function FinanceHistoryPage() {
-  const { data, mutate } = useSWR<HistoryItem[]>('/api/v1/report/budget/history', fetcher)
+  const { data, mutate } = useSWR<HistoryItem[]>(
+    '/api/v1/report/budget/history',
+    fetcher,
+    { refreshInterval: 30000 },
+  )
   const update = useFinanceUpdates()
   useEffect(() => {
     if (update) mutate()

--- a/app/finance/page.tsx
+++ b/app/finance/page.tsx
@@ -11,6 +11,7 @@ export default function FinancePage() {
   const { data, mutate } = useSWR<BudgetOption[]>(
     `/api/v1/report/budget?budget=${budget}&payoffTime=${payoffTime}`,
     fetcher,
+    { refreshInterval: 30000 },
   )
 
   const update = useFinanceUpdates()

--- a/app/panels/FinancePanel.tsx
+++ b/app/panels/FinancePanel.tsx
@@ -10,6 +10,7 @@ export default function FinancePanel() {
   const { data, mutate } = useSWR<BudgetOption[]>(
     `/api/v1/report/budget?budget=${budget}&payoffTime=${payoffTime}`,
     fetcher,
+    { refreshInterval: 30000 },
   )
 
   const ranked = rankBudgetOptions(

--- a/app/panels/MemoryGraphPanel.tsx
+++ b/app/panels/MemoryGraphPanel.tsx
@@ -10,7 +10,11 @@ const ForceGraph2D = dynamic(
 )
 
 export default function MemoryGraphPanel() {
-  const { data } = useSWR<{ nodes: any[]; edges: any[] }>('/api/memory/graph', fetcher)
+  const { data } = useSWR<{ nodes: any[]; edges: any[] }>(
+    '/api/memory/graph',
+    fetcher,
+    { refreshInterval: 30000 },
+  )
 
   const graphData = {
     nodes: data?.nodes ?? [],

--- a/lib/swr.tsx
+++ b/lib/swr.tsx
@@ -1,8 +1,24 @@
 'use client'
+import React from 'react'
 import { SWRConfig } from 'swr'
 
 export const fetcher = (url: string) => fetch(url).then(res => res.json())
 
-export function SWRProvider({ children }: { children: React.ReactNode }) {
-  return <SWRConfig value={{ fetcher }}>{children}</SWRConfig>
+function localStorageProvider() {
+  if (typeof window === 'undefined') return new Map()
+  const map = new Map<string, any>(JSON.parse(localStorage.getItem('swr-cache') || '[]'))
+  window.addEventListener('beforeunload', () => {
+    const cache = JSON.stringify(Array.from(map.entries()))
+    localStorage.setItem('swr-cache', cache)
+  })
+  return map
 }
+
+export function SWRProvider({ children }: { children: React.ReactNode }) {
+  return (
+    <SWRConfig value={{ fetcher, refreshInterval: 30000, provider: localStorageProvider }}>
+      {children}
+    </SWRConfig>
+  )
+}
+

--- a/lib/taskCascadence.ts
+++ b/lib/taskCascadence.ts
@@ -1,0 +1,47 @@
+'use client'
+
+type TaskStatusEvent = {
+  type?: string
+  [key: string]: any
+}
+
+type Callback = (event: TaskStatusEvent) => void
+
+let ws: WebSocket | null = null
+const callbacks = new Set<Callback>()
+
+function ensureConnection() {
+  if (ws || typeof window === 'undefined') return
+  const url = process.env.NEXT_PUBLIC_TASK_CASCADENCE_WS_URL
+  if (!url) {
+    console.error('TaskCascadence WebSocket URL is not defined')
+    return
+  }
+  ws = new WebSocket(url)
+  ws.onmessage = (event: MessageEvent) => {
+    try {
+      const data = JSON.parse(event.data)
+      if (data.type === 'task.status') {
+        callbacks.forEach(cb => cb(data))
+      }
+    } catch (err) {
+      console.error('Error parsing TaskCascadence message', err)
+    }
+  }
+  ws.onclose = () => {
+    ws = null
+  }
+}
+
+export function subscribeToTaskStatus(callback: Callback) {
+  callbacks.add(callback)
+  ensureConnection()
+  return () => {
+    callbacks.delete(callback)
+    if (!callbacks.size && ws) {
+      ws.close()
+      ws = null
+    }
+  }
+}
+

--- a/tests/periodic-refresh.test.tsx
+++ b/tests/periodic-refresh.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import useSWR from 'swr'
+import { SWRProvider } from '../lib/swr'
+import { act } from 'react-dom/test-utils'
+
+function render(ui: React.ReactElement) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = ReactDOM.createRoot(container)
+  act(() => {
+    root.render(ui)
+  })
+  return { container, root }
+}
+
+describe('SWR periodic refresh', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('revalidates on a fixed interval', async () => {
+    const fetchSpy = vi.fn(() => Promise.resolve('data'))
+    function Comp() {
+      useSWR('/api/ume/idea-seeds', fetchSpy)
+      return null
+    }
+    render(
+      <SWRProvider>
+        <Comp />
+      </SWRProvider>
+    )
+    await act(async () => {})
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    await act(async () => {
+      vi.advanceTimersByTime(31000)
+    })
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+  })
+})

--- a/tests/swr-cache.test.tsx
+++ b/tests/swr-cache.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import useSWR from 'swr'
+import { SWRProvider } from '../lib/swr'
+import { act } from 'react-dom/test-utils'
+
+function render(ui: React.ReactElement) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = ReactDOM.createRoot(container)
+  act(() => {
+    root.render(ui)
+  })
+  return { container, root }
+}
+
+describe('SWR local cache', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.restoreAllMocks()
+  })
+
+  it('stores responses in and reads from localStorage', async () => {
+    const key = '/api/ume/idea-seeds'
+    const result = [{ id: '1', text: 'server' }]
+    const fetchSpy = vi.fn(() => Promise.resolve(result))
+
+    function Comp() {
+      const { data } = useSWR(key, fetchSpy)
+      return <div>{data ? data[0].text : ''}</div>
+    }
+
+    render(
+      <SWRProvider>
+        <Comp />
+      </SWRProvider>
+    )
+    await act(async () => {})
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    window.dispatchEvent(new Event('beforeunload'))
+    expect(localStorage.getItem('swr-cache')).toContain('server')
+
+    const fetchSpy2 = vi.fn(() => Promise.resolve(result))
+    function Comp2() {
+      const { data } = useSWR(key, fetchSpy2)
+      return <div>{data ? data[0].text : ''}</div>
+    }
+
+    const { container: container2 } = render(
+      <SWRProvider>
+        <Comp2 />
+      </SWRProvider>
+    )
+    await act(async () => {})
+    expect(container2.textContent).toBe('server')
+    expect(fetchSpy2).toHaveBeenCalledTimes(0)
+  })
+})


### PR DESCRIPTION
## Summary
- add TaskCascadence websocket subscription service
- enhance SWR provider with 30s revalidation and localStorage cache
- refresh data periodically across SWR consumers

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ec05eb1588326a6187581193fdeeb