### PR TITLE
Show actions for finance history items

### DIFF
--- a/app/api/v1/report/budget/history/[id]/route.ts
+++ b/app/api/v1/report/budget/history/[id]/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server'
+import { getRequestContext } from '../../../../../../../lib/context'
+
+type Action = { id: string; description: string }
+
+const personal: Record<string, Action[]> = {
+  '1': [
+    { id: '1a', description: 'Reduce dining out expenses' },
+    { id: '1b', description: 'Cancel unused subscriptions' },
+  ],
+  '2': [
+    { id: '2a', description: 'Negotiate rent reduction' },
+    { id: '2b', description: 'Switch to lower-cost utilities provider' },
+  ],
+}
+
+const group: Record<string, Action[]> = {
+  g1: [
+    { id: 'g1a', description: 'Consolidate group purchases' },
+    { id: 'g1b', description: 'Review shared service contracts' },
+  ],
+  g2: [
+    { id: 'g2a', description: 'Implement energy-saving initiatives' },
+    { id: 'g2b', description: 'Optimize office supply orders' },
+  ],
+}
+
+export async function GET(req: Request, { params }: { params: { id: string } }) {
+  const ctx = getRequestContext(req)
+  const actions = ctx === 'group' ? group[params.id] : personal[params.id]
+  return NextResponse.json(actions ?? [])
+}

--- a/tests/finance-history-page.test.tsx
+++ b/tests/finance-history-page.test.tsx
@@ -30,5 +30,27 @@ describe('FinanceHistoryPage', () => {
     expect(container.textContent).toContain('2024-01-01');
     expect(container.textContent).toContain('Total Cost: $123');
   });
-});
 
+  it('shows actions for a selected history item and returns back', () => {
+    swrMock = vi.fn((key: string) => {
+      if (key === '/api/v1/report/budget/history') {
+        return { data: [{ id: '1', date: '2024-01-01', totalCost: 123 }], mutate: vi.fn() };
+      }
+      if (key === '/api/v1/report/budget/history/1') {
+        return { data: [{ id: 'a1', description: 'Cut coffee spend' }] };
+      }
+      return {};
+    });
+    const { container } = render(<FinanceHistoryPage />);
+    const btn = container.querySelector('button') as HTMLButtonElement;
+    act(() => {
+      btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(container.textContent).toContain('Cut coffee spend');
+    const back = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === 'Back') as HTMLButtonElement;
+    act(() => {
+      back.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(container.textContent).toContain('Total Cost: $123');
+  });
+});

--- a/tests/history-detail.api.test.ts
+++ b/tests/history-detail.api.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+
+describe('budget history detail API route', () => {
+  it('returns actions scoped to context', async () => {
+    const { GET } = await import('../app/api/v1/report/budget/history/[id]/route')
+
+    const resPersonal = await GET(new Request('http://test'), { params: { id: '1' } })
+    const dataPersonal = await resPersonal.json()
+    expect(dataPersonal).toEqual([
+      { id: '1a', description: 'Reduce dining out expenses' },
+      { id: '1b', description: 'Cancel unused subscriptions' },
+    ])
+
+    const resGroup = await GET(
+      new Request('http://test', { headers: { cookie: 'context=group' } }),
+      { params: { id: 'g1' } },
+    )
+    const dataGroup = await resGroup.json()
+    expect(dataGroup).toEqual([
+      { id: 'g1a', description: 'Consolidate group purchases' },
+      { id: 'g1b', description: 'Review shared service contracts' },
+    ])
+  })
+})


### PR DESCRIPTION
## Summary
- allow selecting past finance analyses to reveal associated suggested actions
- serve dummy action data via new `/api/v1/report/budget/history/[id]` route
- test finance history interactions and new API endpoint

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fc8bc87e88326aa9eda8c9b64aeaf