### PR TITLE
feat: enhance finance option display

### DIFF
--- a/app/finance/page.tsx
+++ b/app/finance/page.tsx
@@ -15,8 +15,27 @@ export default function FinancePage() {
   )
 
   const update = useFinanceUpdates()
+  const [paymentSchedules, setPaymentSchedules] = useState<Record<string, any[]>>({})
+  const [aiExplanations, setAiExplanations] = useState<Record<string, string>>({})
   useEffect(() => {
-    if (update) mutate()
+    if (!update) return
+    mutate()
+    const category = update.category ?? update.data?.category ?? 'default'
+    if (update.type === 'finance.decision.result') {
+      const schedule =
+        update.paymentSchedule ??
+        update.data?.paymentSchedule ??
+        update.schedule ??
+        []
+      setPaymentSchedules((prev) => ({ ...prev, [category]: schedule }))
+    } else if (update.type === 'finance.explain.result') {
+      const explanation =
+        update.explanation ??
+        update.data?.explanation ??
+        update.message ??
+        ''
+      setAiExplanations((prev) => ({ ...prev, [category]: explanation }))
+    }
   }, [update, mutate])
 
   const ranked = rankBudgetOptions(
@@ -28,6 +47,9 @@ export default function FinancePage() {
   )
 
   const [selected, setSelected] = useState<typeof ranked[0] | null>(null)
+  const minCost = ranked.length
+    ? Math.min(...ranked.map((o) => o.costOfDeviation))
+    : Infinity
 
   return (
     <div className="p-4">
@@ -56,28 +78,51 @@ export default function FinancePage() {
         </button>
       </div>
       <div className="grid gap-4 md:grid-cols-2">
-        {ranked.map((option) => (
-          <div key={option.category} className="border p-4 rounded shadow">
-            <div className="font-bold mb-2">
-              #{option.rank} {option.category}
-            </div>
-            <p>Amount: ${option.amount}</p>
-            <p>Cost of deviation: ${option.costOfDeviation}</p>
-            <button
-              className="mt-2 text-blue-500 underline"
-              onClick={() => setSelected(option)}
+        {ranked.map((option, idx) => {
+          const label = String.fromCharCode(65 + idx)
+          const isBest = option.costOfDeviation === minCost
+          return (
+            <div
+              key={option.category}
+              className={`border p-4 rounded shadow ${
+                isBest ? 'border-green-500 bg-green-50' : ''
+              }`}
             >
-              View Details
-            </button>
-          </div>
-        ))}
+              <div className="font-bold mb-2">
+                Option {label} - {option.category}
+              </div>
+              <p>Amount: ${option.amount}</p>
+              <p>Cost of deviation: ${option.costOfDeviation}</p>
+              <button
+                className="mt-2 text-blue-500 underline"
+                onClick={() => setSelected(option)}
+              >
+                View Details
+              </button>
+            </div>
+          )
+        })}
       </div>
       {selected && (
         <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50">
           <div className="bg-white p-6 rounded shadow-lg max-w-sm w-full">
             <h2 className="text-lg font-bold mb-2">{selected.category} Details</h2>
-            <p className="mb-2">Payment schedule coming soon.</p>
-            <p className="mb-4">AI explanation coming soon.</p>
+            {paymentSchedules[selected.category] ? (
+              <ul className="mb-2 list-disc pl-5">
+                {paymentSchedules[selected.category].map((item, i) => (
+                  <li key={i}>{typeof item === 'string' ? item : JSON.stringify(item)}</li>
+                ))}
+              </ul>
+            ) : (
+              <p className="mb-2">Payment schedule coming soon.</p>
+            )}
+            {aiExplanations[selected.category] ? (
+              <p className="mb-4 whitespace-pre-wrap">
+                {aiExplanations[selected.category]}
+              </p>
+            ) : (
+              <p className="mb-4">AI explanation coming soon.</p>
+            )}
             <div className="flex justify-end">
               <button
                 className="px-4 py-2 bg-gray-200 rounded"

--- a/app/panels/FinancePanel.tsx
+++ b/app/panels/FinancePanel.tsx
@@ -1,8 +1,9 @@
 'use client'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import useSWR from 'swr'
 import { fetcher } from '../../lib/swr'
 import { BudgetOption, rankBudgetOptions } from '../../lib/finance'
+import { useFinanceUpdates } from '../socket-context'
 
 export default function FinancePanel() {
   const [budget, setBudget] = useState(1000)
@@ -13,6 +14,30 @@ export default function FinancePanel() {
     { refreshInterval: 30000 },
   )
 
+  const update = useFinanceUpdates()
+  const [paymentSchedules, setPaymentSchedules] = useState<Record<string, any[]>>({})
+  const [aiExplanations, setAiExplanations] = useState<Record<string, string>>({})
+  useEffect(() => {
+    if (!update) return
+    mutate()
+    const category = update.category ?? update.data?.category ?? 'default'
+    if (update.type === 'finance.decision.result') {
+      const schedule =
+        update.paymentSchedule ??
+        update.data?.paymentSchedule ??
+        update.schedule ??
+        []
+      setPaymentSchedules((prev) => ({ ...prev, [category]: schedule }))
+    } else if (update.type === 'finance.explain.result') {
+      const explanation =
+        update.explanation ??
+        update.data?.explanation ??
+        update.message ??
+        ''
+      setAiExplanations((prev) => ({ ...prev, [category]: explanation }))
+    }
+  }, [update, mutate])
+
   const ranked = rankBudgetOptions(
     (data ?? [
       { category: 'Rent', amount: 1000 },
@@ -22,6 +47,9 @@ export default function FinancePanel() {
   )
 
   const [selected, setSelected] = useState<typeof ranked[0] | null>(null)
+  const minCost = ranked.length
+    ? Math.min(...ranked.map((o) => o.costOfDeviation))
+    : Infinity
 
   return (
     <div className="p-4">
@@ -50,28 +78,51 @@ export default function FinancePanel() {
         </button>
       </div>
       <div className="grid gap-4 md:grid-cols-2">
-        {ranked.map((option) => (
-          <div key={option.category} className="border p-4 rounded shadow">
-            <div className="font-bold mb-2">
-              #{option.rank} {option.category}
-            </div>
-            <p>Amount: ${option.amount}</p>
-            <p>Cost of deviation: ${option.costOfDeviation}</p>
-            <button
-              className="mt-2 text-blue-500 underline"
-              onClick={() => setSelected(option)}
+        {ranked.map((option, idx) => {
+          const label = String.fromCharCode(65 + idx)
+          const isBest = option.costOfDeviation === minCost
+          return (
+            <div
+              key={option.category}
+              className={`border p-4 rounded shadow ${
+                isBest ? 'border-green-500 bg-green-50' : ''
+              }`}
             >
-              View Details
-            </button>
-          </div>
-        ))}
+              <div className="font-bold mb-2">
+                Option {label} - {option.category}
+              </div>
+              <p>Amount: ${option.amount}</p>
+              <p>Cost of deviation: ${option.costOfDeviation}</p>
+              <button
+                className="mt-2 text-blue-500 underline"
+                onClick={() => setSelected(option)}
+              >
+                View Details
+              </button>
+            </div>
+          )
+        })}
       </div>
       {selected && (
         <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50">
           <div className="bg-white p-6 rounded shadow-lg max-w-sm w-full">
             <h2 className="text-lg font-bold mb-2">{selected.category} Details</h2>
-            <p className="mb-2">Payment schedule coming soon.</p>
-            <p className="mb-4">AI explanation coming soon.</p>
+            {paymentSchedules[selected.category] ? (
+              <ul className="mb-2 list-disc pl-5">
+                {paymentSchedules[selected.category].map((item, i) => (
+                  <li key={i}>{typeof item === 'string' ? item : JSON.stringify(item)}</li>
+                ))}
+              </ul>
+            ) : (
+              <p className="mb-2">Payment schedule coming soon.</p>
+            )}
+            {aiExplanations[selected.category] ? (
+              <p className="mb-4 whitespace-pre-wrap">
+                {aiExplanations[selected.category]}
+              </p>
+            ) : (
+              <p className="mb-4">AI explanation coming soon.</p>
+            )}
             <div className="flex justify-end">
               <button
                 className="px-4 py-2 bg-gray-200 rounded"


### PR DESCRIPTION
## Summary
- label finance option cards sequentially and highlight best cost deviation
- show payment schedules and AI explanations in finance detail modals
- sync dashboard finance panel with page behavior

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fc8bc009883269316a08b59676d69