### PR TITLE
feat: manage calendar layer visibility

### DIFF
--- a/app/panels/CalendarPanel.tsx
+++ b/app/panels/CalendarPanel.tsx
@@ -34,25 +34,25 @@ export default function CalendarPanel() {
     fetcher,
     { refreshInterval: 30000 },
   )
-  const [selectedLayers, setSelectedLayers] = useState<string[]>([])
+  const [visibleLayers, setVisibleLayers] = useState<string[]>([])
 
   useEffect(() => {
-    setSelectedLayers(data.layers.map(l => l.id))
+    setVisibleLayers(data.layers.map(l => l.id))
   }, [data.layers])
 
   const toggleLayer = (id: string) => {
-    setSelectedLayers(prev =>
+    setVisibleLayers(prev =>
       prev.includes(id) ? prev.filter(l => l !== id) : [...prev, id]
     )
   }
 
   return (
     <div>
-      <CalendarLayerPanel layers={data.layers} selected={selectedLayers} onToggle={toggleLayer} />
+      <CalendarLayerPanel layers={data.layers} selected={visibleLayers} onToggle={toggleLayer} />
       <ScheduleCalendar
         events={data.events}
         layers={data.layers}
-        visibleLayers={selectedLayers}
+        visibleLayers={visibleLayers}
         mutate={mutate}
       />
     </div>


### PR DESCRIPTION
## Summary
- load schedule data with `useSWR`
- manage calendar layer visibility and toggling
- forward events and visibility to `ScheduleCalendar`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894a81270188326bdf85afd6fa38bf1