### PR TITLE
Add default WebSocket URL

### DIFF
--- a/app/socket-context.tsx
+++ b/app/socket-context.tsx
@@ -32,11 +32,7 @@ export function SocketProvider({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
-    const url = process.env.NEXT_PUBLIC_WS_URL;
-    if (!url) {
-      console.error('WebSocket URL is not defined');
-      return;
-    }
+    const url = process.env.NEXT_PUBLIC_WS_URL ?? 'ws://localhost:3001';
 
     let ws: WebSocket;
     let reconnectAttempts = 0;

--- a/tests/socket-events.test.tsx
+++ b/tests/socket-events.test.tsx
@@ -27,11 +27,12 @@ function render(ui: React.ReactElement) {
 
 describe('socket event propagation', () => {
   let onmessage: ((ev: any) => void) | null;
+  const originalEnv = process.env.NEXT_PUBLIC_WS_URL;
 
   beforeEach(() => {
     document.body.innerHTML = '';
     onmessage = null;
-    process.env.NEXT_PUBLIC_WS_URL = 'ws://example.test';
+    delete process.env.NEXT_PUBLIC_WS_URL;
     const wsInstance: any = {
       close: vi.fn(),
       set onmessage(fn) {
@@ -46,7 +47,11 @@ describe('socket event propagation', () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
-    delete process.env.NEXT_PUBLIC_WS_URL;
+    if (originalEnv === undefined) {
+      delete process.env.NEXT_PUBLIC_WS_URL;
+    } else {
+      process.env.NEXT_PUBLIC_WS_URL = originalEnv;
+    }
   });
 
   it('refreshes calendar when an event is created', async () => {

--- a/tests/socket-provider.test.tsx
+++ b/tests/socket-provider.test.tsx
@@ -19,12 +19,16 @@ describe('SocketProvider', () => {
 
   beforeEach(() => {
     document.body.innerHTML = '';
-    process.env.NEXT_PUBLIC_WS_URL = 'ws://example.test';
+    delete process.env.NEXT_PUBLIC_WS_URL;
   });
 
   afterEach(() => {
     vi.unstubAllGlobals();
-    process.env.NEXT_PUBLIC_WS_URL = originalEnv;
+    if (originalEnv === undefined) {
+      delete process.env.NEXT_PUBLIC_WS_URL;
+    } else {
+      process.env.NEXT_PUBLIC_WS_URL = originalEnv;
+    }
   });
 
   it('provides a WebSocket instance after initialization', async () => {
@@ -46,7 +50,7 @@ describe('SocketProvider', () => {
 
     await act(async () => {});
 
-    expect(wsMock).toHaveBeenCalledWith('ws://example.test');
+    expect(wsMock).toHaveBeenCalledWith('ws://localhost:3001');
     expect(socket).toBe(wsInstance);
   });
 });


### PR DESCRIPTION
## Summary
- default WebSocket URL to localhost when NEXT_PUBLIC_WS_URL is absent
- update socket provider tests for fallback behavior
- adjust socket event tests to respect env var restore

## Testing
- `npm run lint`
- `NODE_OPTIONS=--max-old-space-size=8192 npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6894b8ea4e0c8326ad66dca9cad4565e