### PR TITLE
Expose latest task status via socket context

### DIFF
--- a/app/components/ScheduleCalendar.tsx
+++ b/app/components/ScheduleCalendar.tsx
@@ -6,7 +6,7 @@ import dayGridPlugin, { DayCellContentArg } from '@fullcalendar/daygrid'
 import timeGridPlugin from '@fullcalendar/timegrid'
 import interactionPlugin, { EventDropArg, DateClickArg } from '@fullcalendar/interaction'
 import { EventContentArg, EventMountArg } from '@fullcalendar/core'
-import { useCalendarEvents } from '../socket-context'
+import { useCalendarEvents, useTaskStatus } from '../socket-context'
 
 interface Layer {
   id: string
@@ -34,11 +34,16 @@ interface ScheduleCalendarProps {
 
 export default function ScheduleCalendar({ events, layers, visibleLayers, mutate }: ScheduleCalendarProps) {
   const event = useCalendarEvents()
+  const taskStatus = useTaskStatus()
   const [selectedDate, setSelectedDate] = useState<string | null>(null)
 
   useEffect(() => {
     if (event) mutate()
   }, [event, mutate])
+
+  useEffect(() => {
+    if (taskStatus) mutate()
+  }, [taskStatus, mutate])
 
   const filtered = events
     .filter(e => !e.layer || visibleLayers.includes(e.layer))

--- a/tests/calendar-page.test.tsx
+++ b/tests/calendar-page.test.tsx
@@ -23,6 +23,7 @@ vi.mock('../app/socket-context', () => ({
   useSocket: () => socketMock,
   useCalendarEvents: () => null,
   useFinanceUpdates: () => null,
+  useTaskStatus: () => null,
 }));
 vi.mock('next-auth/react', () => ({
   useSession: () => ({ data: { user: { id: 'user1' } } })

--- a/tests/finance-history-page.test.tsx
+++ b/tests/finance-history-page.test.tsx
@@ -5,7 +5,11 @@ import { act } from 'react-dom/test-utils';
 
 let swrMock: any;
 vi.mock('swr', () => ({ __esModule: true, default: (...args: any[]) => swrMock(...args) }));
-vi.mock('../app/socket-context', () => ({ __esModule: true, useFinanceUpdates: () => null }));
+vi.mock('../app/socket-context', () => ({
+  __esModule: true,
+  useFinanceUpdates: () => null,
+  useTaskStatus: () => null,
+}));
 
 import FinanceHistoryPage from '../app/finance/history';
 

--- a/tests/finance-page.test.tsx
+++ b/tests/finance-page.test.tsx
@@ -5,7 +5,11 @@ import { act } from 'react-dom/test-utils';
 
 let swrMock: any;
 vi.mock('swr', () => ({ __esModule: true, default: (...args: any[]) => swrMock(...args) }));
-vi.mock('../app/socket-context', () => ({ __esModule: true, useFinanceUpdates: () => null }));
+vi.mock('../app/socket-context', () => ({
+  __esModule: true,
+  useFinanceUpdates: () => null,
+  useTaskStatus: () => null,
+}));
 
 import FinancePage from '../app/finance/page';
 

--- a/tests/invest-page.test.tsx
+++ b/tests/invest-page.test.tsx
@@ -11,6 +11,7 @@ let emit: (value: number) => void;
 vi.mock('../app/socket-context', () => ({
   __esModule: true,
   useSocket: () => ws,
+  useTaskStatus: () => null,
 }));
 
 vi.mock('recharts', () => {


### PR DESCRIPTION
## Summary
- track latest task status events in TaskCascadence and provide a React hook
- extend socket context to subscribe to TaskCascadence and expose task status
- refresh calendar on task updates and adjust tests for new hook

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6894c2b2132c832690debd8c4915e95a