### PR TITLE
Protect budget reports with session auth

### DIFF
--- a/app/api/v1/report/budget/history/route.ts
+++ b/app/api/v1/report/budget/history/route.ts
@@ -1,8 +1,23 @@
 import { NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '../../../../auth/[...nextauth]/route'
 import { getRequestContext } from '../../../../../../lib/context'
 
 export async function GET(req: Request) {
+  const session = await getServerSession(authOptions)
+  if (!session) {
+    return new Response('Unauthorized', { status: 401 })
+  }
   const ctx = getRequestContext(req)
+  if (ctx === 'group') {
+    const cookie = req.headers.get('cookie') || ''
+    const match = cookie.match(/(?:^|; )context=([^;]+)/)
+    const requested = match ? decodeURIComponent(match[1]) : ''
+    const groups = session.user?.groups ?? []
+    if (!groups.includes(requested)) {
+      return new Response('Forbidden', { status: 403 })
+    }
+  }
   const personal = [
     { id: '1', date: '2024-01-01', totalCost: 1200 },
     { id: '2', date: '2024-02-01', totalCost: 1300 },

--- a/app/api/v1/report/budget/route.ts
+++ b/app/api/v1/report/budget/route.ts
@@ -1,8 +1,23 @@
 import { NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '../../../auth/[...nextauth]/route'
 import { getRequestContext } from '../../../../../lib/context'
 
 export async function GET(req: Request) {
+  const session = await getServerSession(authOptions)
+  if (!session) {
+    return new Response('Unauthorized', { status: 401 })
+  }
   const ctx = getRequestContext(req)
+  if (ctx === 'group') {
+    const cookie = req.headers.get('cookie') || ''
+    const match = cookie.match(/(?:^|; )context=([^;]+)/)
+    const requested = match ? decodeURIComponent(match[1]) : ''
+    const groups = session.user?.groups ?? []
+    if (!groups.includes(requested)) {
+      return new Response('Forbidden', { status: 403 })
+    }
+  }
   const personal = [
     { category: 'Rent', amount: 1000 },
     { category: 'Food', amount: 300 },

--- a/tests/api-routes.test.ts
+++ b/tests/api-routes.test.ts
@@ -151,8 +151,13 @@ describe('schedule API routes', () => {
 
 describe('budget report API route', () => {
   it('returns personal and group budget data based on context', async () => {
+    vi.mocked(getServerSession).mockResolvedValue({
+      user: { id: '1', groups: ['group'] },
+    })
     const { GET } = await import('../app/api/v1/report/budget/route')
-    const resPersonal = await GET(new Request('http://test', { headers: { cookie: 'context=personal' } }))
+    const resPersonal = await GET(
+      new Request('http://test', { headers: { cookie: 'context=personal' } }),
+    )
     const dataPersonal = await resPersonal.json()
     expect(dataPersonal).toEqual([
       { category: 'Rent', amount: 1000 },
@@ -160,7 +165,9 @@ describe('budget report API route', () => {
       { category: 'Utilities', amount: 150 },
     ])
 
-    const resGroup = await GET(new Request('http://test', { headers: { cookie: 'context=group' } }))
+    const resGroup = await GET(
+      new Request('http://test', { headers: { cookie: 'context=group' } }),
+    )
     const dataGroup = await resGroup.json()
     expect(dataGroup).toEqual([
       { category: 'Office Rent', amount: 2000 },

--- a/tests/finance-auth.api.test.ts
+++ b/tests/finance-auth.api.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { getServerSession } from 'next-auth'
+
+vi.mock('next-auth', async () => {
+  const actual = await vi.importActual<any>('next-auth')
+  return {
+    ...actual,
+    getServerSession: vi.fn(),
+  }
+})
+
+afterEach(() => {
+  vi.resetModules()
+  vi.clearAllMocks()
+})
+
+describe('finance report auth', () => {
+  const routes: [string, any][] = [
+    ['../app/api/v1/report/budget/route', undefined],
+    ['../app/api/v1/report/budget/history/route', undefined],
+    ['../app/api/v1/report/budget/history/[id]/route', { params: { id: 'g1' } }],
+  ]
+
+  it.each(routes)('returns 401 when unauthenticated for %s', async (path, params) => {
+    vi.mocked(getServerSession).mockResolvedValue(null)
+    const mod: any = await import(path)
+    const res = await mod.GET(
+      new Request('http://test', { headers: { cookie: 'context=personal' } }),
+      params,
+    )
+    expect(res.status).toBe(401)
+  })
+
+  it.each(routes)('returns 403 for unauthorized group access on %s', async (path, params) => {
+    vi.mocked(getServerSession).mockResolvedValue({ user: { id: '1', groups: [] } })
+    const mod: any = await import(path)
+    const res = await mod.GET(
+      new Request('http://test', { headers: { cookie: 'context=group' } }),
+      params,
+    )
+    expect(res.status).toBe(403)
+  })
+})

--- a/tests/history-detail.api.test.ts
+++ b/tests/history-detail.api.test.ts
@@ -1,10 +1,24 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
+import { getServerSession } from 'next-auth'
+
+vi.mock('next-auth', async () => {
+  const actual = await vi.importActual<any>('next-auth')
+  return {
+    ...actual,
+    getServerSession: vi.fn(),
+  }
+})
 
 describe('budget history detail API route', () => {
   it('returns actions scoped to context', async () => {
+    vi.mocked(getServerSession).mockResolvedValue({
+      user: { id: '1', groups: ['group'] },
+    })
     const { GET } = await import('../app/api/v1/report/budget/history/[id]/route')
 
-    const resPersonal = await GET(new Request('http://test'), { params: { id: '1' } })
+    const resPersonal = await GET(new Request('http://test'), {
+      params: { id: '1' },
+    })
     const dataPersonal = await resPersonal.json()
     expect(dataPersonal).toEqual([
       { id: '1a', description: 'Reduce dining out expenses' },

--- a/tests/history.api.test.ts
+++ b/tests/history.api.test.ts
@@ -1,16 +1,32 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
+import { getServerSession } from 'next-auth'
+
+vi.mock('next-auth', async () => {
+  const actual = await vi.importActual<any>('next-auth')
+  return {
+    ...actual,
+    getServerSession: vi.fn(),
+  }
+})
 
 describe('budget history API route', () => {
   it('returns history scoped to context', async () => {
+    vi.mocked(getServerSession).mockResolvedValue({
+      user: { id: '1', groups: ['group'] },
+    })
     const { GET } = await import('../app/api/v1/report/budget/history/route')
-    const resPersonal = await GET(new Request('http://test', { headers: { cookie: 'context=personal' } }))
+    const resPersonal = await GET(
+      new Request('http://test', { headers: { cookie: 'context=personal' } }),
+    )
     const dataPersonal = await resPersonal.json()
     expect(dataPersonal).toEqual([
       { id: '1', date: '2024-01-01', totalCost: 1200 },
       { id: '2', date: '2024-02-01', totalCost: 1300 },
     ])
 
-    const resGroup = await GET(new Request('http://test', { headers: { cookie: 'context=group' } }))
+    const resGroup = await GET(
+      new Request('http://test', { headers: { cookie: 'context=group' } }),
+    )
     const dataGroup = await resGroup.json()
     expect(dataGroup).toEqual([
       { id: 'g1', date: '2024-01-01', totalCost: 5000 },


### PR DESCRIPTION
## Summary
- require a server session for budget report endpoints
- block group requests unless the user belongs to the requested group
- test unauthenticated and unauthorized access to finance routes

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894cbaab25c8326b6cb501f567a5851