### PR TITLE
feat: notify calendar websocket on event changes

### DIFF
--- a/app/api/schedule/route.ts
+++ b/app/api/schedule/route.ts
@@ -2,6 +2,7 @@ import { getData, addEvent, validateEvent } from './store'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '../auth/[...nextauth]/route'
 import { getRequestContext } from '../../../lib/context'
+import { sendWsMessage } from '../../../lib/ws-server'
 
 export async function GET(req: Request) {
   const session = await getServerSession(authOptions)
@@ -38,6 +39,7 @@ export async function POST(req: Request) {
       return new Response('Forbidden', { status: 403 })
     }
     await addEvent(event)
+    sendWsMessage({ type: 'calendar.event.created', event })
     return Response.json({ success: true })
   } catch (e: any) {
     return Response.json({ error: e.message }, { status: 400 })

--- a/app/api/task/[id]/route.ts
+++ b/app/api/task/[id]/route.ts
@@ -2,6 +2,7 @@ import { getEvent, updateEvent, validateEventPatch } from '../../schedule/store'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '../../auth/[...nextauth]/route'
 import { getRequestContext } from '../../../../lib/context'
+import { sendWsMessage } from '../../../../lib/ws-server'
 
 export async function GET(
   req: Request,
@@ -53,6 +54,8 @@ export async function PATCH(
   try {
     const patch = validateEventPatch(body)
     await updateEvent(params.id, patch)
+    const updated = { ...existing, ...patch }
+    sendWsMessage({ type: 'calendar.event.updated', event: updated })
     return Response.json({ success: true })
   } catch (e: any) {
     return Response.json({ error: e.message }, { status: 400 })

--- a/lib/ws-server.ts
+++ b/lib/ws-server.ts
@@ -1,0 +1,33 @@
+let socket: WebSocket | null = null;
+let WsConstructor: typeof WebSocket | null = null;
+
+function getConstructor(): typeof WebSocket | null {
+  if (WsConstructor) return WsConstructor;
+  if (typeof WebSocket !== 'undefined') {
+    WsConstructor = WebSocket;
+    return WsConstructor;
+  }
+  try {
+    WsConstructor = require('ws');
+    return WsConstructor;
+  } catch {
+    return null;
+  }
+}
+
+function getSocket(): WebSocket | null {
+  const url = process.env.NEXT_PUBLIC_WS_URL;
+  const Ctor = getConstructor();
+  if (!url || !Ctor) return null;
+  if (!socket || socket.readyState === Ctor.CLOSED) {
+    socket = new Ctor(url);
+  }
+  return socket;
+}
+
+export function sendWsMessage(data: any): void {
+  const ws = getSocket();
+  if (!ws || ws.readyState !== ws.OPEN) return;
+  ws.send(JSON.stringify(data));
+}
+

--- a/tests/calendar-websocket.api.test.ts
+++ b/tests/calendar-websocket.api.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { promises as fs } from 'fs'
+import os from 'os'
+import path from 'path'
+import { getServerSession } from 'next-auth'
+
+vi.mock('next-auth', async () => {
+  const actual = await vi.importActual<any>('next-auth')
+  return {
+    ...actual,
+    getServerSession: vi.fn(),
+  }
+})
+
+async function loadModules() {
+  vi.resetModules()
+  const schedule = await import('../app/api/schedule/route')
+  const task = await import('../app/api/task/[id]/route')
+  return { schedule, task }
+}
+
+describe('calendar websocket notifications', () => {
+  const file = path.join(os.tmpdir(), 'events.ws.test.json')
+  const originalEnv = process.env.NEXT_PUBLIC_WS_URL
+
+  afterEach(async () => {
+    await fs.unlink(file).catch(() => {})
+    delete process.env.SCHEDULE_DATA_FILE
+    if (originalEnv === undefined) {
+      delete process.env.NEXT_PUBLIC_WS_URL
+    } else {
+      process.env.NEXT_PUBLIC_WS_URL = originalEnv
+    }
+    vi.clearAllMocks()
+  })
+
+  it('sends messages on create and update', async () => {
+    process.env.NEXT_PUBLIC_WS_URL = 'ws://test'
+    process.env.SCHEDULE_DATA_FILE = file
+    await fs.writeFile(file, JSON.stringify({ events: [], layers: [] }))
+
+    vi.mocked(getServerSession).mockResolvedValue({ user: { id: '1' } })
+
+    const send = vi.fn()
+    const wsInstance: any = { send, readyState: 1, OPEN: 1 }
+    const wsMock = vi.fn(() => wsInstance)
+    vi.stubGlobal('WebSocket', wsMock)
+
+    const {
+      schedule: { POST },
+      task: { PATCH },
+    } = await loadModules()
+
+    const event = { id: '1', start: '2024-01-01', shared: false }
+    const postReq = new Request('http://test', {
+      method: 'POST',
+      body: JSON.stringify(event),
+      headers: { 'Content-Type': 'application/json', cookie: 'context=personal' },
+    })
+    await POST(postReq)
+    expect(send).toHaveBeenCalledTimes(1)
+    expect(JSON.parse(send.mock.calls[0][0])).toMatchObject({
+      type: 'calendar.event.created',
+      event,
+    })
+
+    const patchReq = new Request('http://test', {
+      method: 'PATCH',
+      body: JSON.stringify({ title: 'Updated' }),
+      headers: { 'Content-Type': 'application/json', cookie: 'context=personal' },
+    })
+    await PATCH(patchReq, { params: { id: event.id } })
+    expect(send).toHaveBeenCalledTimes(2)
+    expect(JSON.parse(send.mock.calls[1][0])).toMatchObject({
+      type: 'calendar.event.updated',
+      event: { ...event, title: 'Updated' },
+    })
+  })
+})
+


### PR DESCRIPTION
## Summary
- send calendar updates over WebSocket on event create/update
- add reusable server-side WebSocket helper
- test calendar WebSocket notifications

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894cbabd7dc8326aba3f8cef656b987