### PR TITLE
Expose task status hook

### DIFF
--- a/app/socket-context.tsx
+++ b/app/socket-context.tsx
@@ -1,9 +1,8 @@
 'use client';
 import React, { createContext, useContext, useEffect, useState } from 'react';
 import {
-  subscribeToTaskStatus,
-  getLatestTaskStatus,
   TaskStatusEvent,
+  useTaskStatus as useTaskStatusSubscription,
 } from '../lib/taskCascadence';
 
 interface SocketContextValue {
@@ -40,7 +39,7 @@ export function SocketProvider({ children }: { children: React.ReactNode }) {
   const [socket, setSocket] = useState<WebSocket | null>(null);
   const [calendarEvent, setCalendarEvent] = useState<any>(null);
   const [financeUpdate, setFinanceUpdate] = useState<any>(null);
-  const [taskStatus, setTaskStatus] = useState<TaskStatusEvent | null>(getLatestTaskStatus());
+  const taskStatus = useTaskStatusSubscription();
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -94,13 +93,6 @@ export function SocketProvider({ children }: { children: React.ReactNode }) {
     return () => {
       if (timeout) clearTimeout(timeout);
       ws.close();
-    };
-  }, []);
-
-  useEffect(() => {
-    const unsubscribe = subscribeToTaskStatus(setTaskStatus);
-    return () => {
-      unsubscribe();
     };
   }, []);
 

--- a/lib/taskCascadence.ts
+++ b/lib/taskCascadence.ts
@@ -53,7 +53,7 @@ export function getLatestTaskStatus() {
   return latestStatus
 }
 
-export function useTaskStatusStream() {
+export function useTaskStatus() {
   const [status, setStatus] = useState<TaskStatusEvent | null>(latestStatus)
   useEffect(() => subscribeToTaskStatus(setStatus), [])
   return status


### PR DESCRIPTION
## Summary
- add a `useTaskStatus` hook that subscribes to Task Cascadence status events
- provide task status updates in `SocketProvider` via the new hook

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68969afd324883268d598ddad3de82e1