### PR TITLE
test: verify socket reconnection and context updates

### DIFF
--- a/tests/socket-provider.test.tsx
+++ b/tests/socket-provider.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { SocketProvider, useSocket } from '../app/socket-context';
+import { SocketProvider, useSocket, useCalendarEvents, useFinanceUpdates } from '../app/socket-context';
 import { act } from 'react-dom/test-utils';
 
 function render(ui: React.ReactElement) {
@@ -52,5 +52,90 @@ describe('SocketProvider', () => {
 
     expect(wsMock).toHaveBeenCalledWith('ws://localhost:3001');
     expect(socket).toBe(wsInstance);
+  });
+
+  it('reconnects with exponential backoff when the socket closes', async () => {
+    vi.useFakeTimers();
+    const wsInstances: any[] = [];
+
+    class MockWebSocket {
+      onopen: ((ev: any) => void) | null = null;
+      onclose: ((ev: any) => void) | null = null;
+      onerror: ((ev: any) => void) | null = null;
+      onmessage: ((ev: any) => void) | null = null;
+      close = vi.fn();
+      constructor() {
+        wsInstances.push(this);
+      }
+    }
+
+    const wsMock = vi.fn(() => new MockWebSocket() as unknown as WebSocket);
+    const setTimeoutSpy = vi.spyOn(global, 'setTimeout');
+    vi.stubGlobal('WebSocket', wsMock);
+
+    render(
+      <SocketProvider>
+        <div />
+      </SocketProvider>
+    );
+
+    await act(async () => {});
+
+    const first = wsInstances[0];
+    first.onclose?.({});
+
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 1000);
+
+    await act(async () => {
+      vi.runOnlyPendingTimers();
+    });
+
+    const second = wsInstances[1];
+    second.onclose?.({});
+
+    expect(setTimeoutSpy).toHaveBeenLastCalledWith(expect.any(Function), 2000);
+
+    vi.useRealTimers();
+  });
+
+  it('updates context fields when messages are received', async () => {
+    const wsInstance: any = {
+      close: vi.fn(),
+      onopen: null,
+      onclose: null,
+      onerror: null,
+      onmessage: null,
+    };
+
+    const wsMock = vi.fn(() => wsInstance as unknown as WebSocket);
+    vi.stubGlobal('WebSocket', wsMock);
+
+    let calendarEvent: any = null;
+    let financeUpdate: any = null;
+    function GetUpdates() {
+      calendarEvent = useCalendarEvents();
+      financeUpdate = useFinanceUpdates();
+      return null;
+    }
+
+    render(
+      <SocketProvider>
+        <GetUpdates />
+      </SocketProvider>
+    );
+
+    await act(async () => {});
+
+    const calendarData = { type: 'calendar.event.created', value: 1 };
+    await act(async () => {
+      wsInstance.onmessage?.({ data: JSON.stringify(calendarData) });
+    });
+    expect(calendarEvent).toEqual(calendarData);
+
+    const financeData = { type: 'finance.decision.result', value: 2 };
+    await act(async () => {
+      wsInstance.onmessage?.({ data: JSON.stringify(financeData) });
+    });
+    expect(financeUpdate).toEqual(financeData);
   });
 });


### PR DESCRIPTION
## Summary
- add tests to ensure WebSocket reconnection uses exponential backoff
- test incoming calendar and finance messages update context fields

## Testing
- `npm run lint`
- `npm test socket-provider`


------
https://chatgpt.com/codex/tasks/task_e_6896ba4bbf848326887f289c44161710