### PR TITLE
Add TaskStatusPanel for live task updates

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -25,6 +25,8 @@ export default function DashboardPage() {
     const saved = window.localStorage.getItem(storageKey)
     if (saved) {
       setLayout(JSON.parse(saved))
+    } else {
+      setLayout([{ i: 'task-status', x: 0, y: 0, w: 3, h: 2 }])
     }
   }, [])
 

--- a/app/panels/TaskStatusPanel.tsx
+++ b/app/panels/TaskStatusPanel.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useTaskStatus } from '../socket-context'
+
+interface StatusEntry {
+  timestamp: number
+  message: string
+}
+
+export default function TaskStatusPanel() {
+  const status = useTaskStatus()
+  const [entries, setEntries] = useState<StatusEntry[]>([])
+
+  useEffect(() => {
+    if (!status) return
+    const message =
+      typeof status.message === 'string'
+        ? status.message
+        : typeof status.status === 'string'
+          ? status.status
+          : status.type || JSON.stringify(status)
+    setEntries(prev => [...prev, { timestamp: Date.now(), message }])
+  }, [status])
+
+  return (
+    <div className="p-2">
+      <h2 className="font-bold mb-2">Task Status</h2>
+      <ul className="space-y-1 text-sm">
+        {entries.map((e, i) => (
+          <li key={i}>
+            <span className="text-gray-500 mr-2">
+              {new Date(e.timestamp).toLocaleTimeString()}
+            </span>
+            {e.message}
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+

--- a/lib/panels.ts
+++ b/lib/panels.ts
@@ -24,6 +24,7 @@ const registry: PanelMetadata[] = [
   { id: 'invest', title: 'Invest Panel', module: '../app/panels/InvestPanel' },
   { id: 'idea-garden', title: 'Idea Garden Panel', module: '../app/panels/IdeaGardenPanel' },
   { id: 'memory-graph', title: 'Memory Graph Panel', module: '../app/panels/MemoryGraphPanel' },
+  { id: 'task-status', title: 'Task Status Panel', module: '../app/panels/TaskStatusPanel' },
   { id: 'settings', title: 'Settings Panel', module: '../app/panels/SettingsPanel' },
 ];
 

--- a/tests/panel-registry.test.ts
+++ b/tests/panel-registry.test.ts
@@ -6,7 +6,7 @@ import { getPanels } from '../lib/panels'
 describe('panel registry', () => {
   it('loads all configured panels', async () => {
     const panels = await getPanels()
-    expect(panels).toHaveLength(8)
+    expect(panels).toHaveLength(9)
     for (const panel of panels) {
       expect(panel.id).toBeTruthy()
       expect(panel.title).toBeTruthy()
@@ -26,6 +26,7 @@ describe('panel registry', () => {
       'invest',
       'idea-garden',
       'memory-graph',
+      'task-status',
       'settings',
     ])
     expect(titles).toEqual([
@@ -36,6 +37,7 @@ describe('panel registry', () => {
       'Invest Panel',
       'Idea Garden Panel',
       'Memory Graph Panel',
+      'Task Status Panel',
       'Settings Panel',
     ])
   })


### PR DESCRIPTION
## Summary
- create TaskStatusPanel that records timestamped task status messages
- register task status panel and default it into dashboard layout
- update panel registry tests for new panel

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896bf4f889c8326844603a2bf3cba1c