### PR TITLE
Verify group membership for budget reports

### DIFF
--- a/app/api/v1/report/budget/history/[id]/route.ts
+++ b/app/api/v1/report/budget/history/[id]/route.ts
@@ -35,14 +35,14 @@ export async function GET(
   if (!session) {
     return new Response('Unauthorized', { status: 401 })
   }
+  const cookie = req.headers.get('cookie') || ''
+  const match = cookie.match(/(?:^|; )context=([^;]+)/)
+  const requested = match ? decodeURIComponent(match[1]) : 'personal'
   const ctx = getRequestContext(req)
   if (ctx === 'group') {
-    const cookie = req.headers.get('cookie') || ''
-    const match = cookie.match(/(?:^|; )context=([^;]+)/)
-    const requested = match ? decodeURIComponent(match[1]) : ''
     const groups = session.user?.groups ?? []
     if (!groups.includes(requested)) {
-      return new Response('Forbidden', { status: 403 })
+      return Response.json({ error: 'Forbidden' }, { status: 403 })
     }
   }
   const actions = ctx === 'group' ? group[params.id] : personal[params.id]

--- a/app/api/v1/report/budget/history/route.ts
+++ b/app/api/v1/report/budget/history/route.ts
@@ -8,14 +8,14 @@ export async function GET(req: Request) {
   if (!session) {
     return new Response('Unauthorized', { status: 401 })
   }
+  const cookie = req.headers.get('cookie') || ''
+  const match = cookie.match(/(?:^|; )context=([^;]+)/)
+  const requested = match ? decodeURIComponent(match[1]) : 'personal'
   const ctx = getRequestContext(req)
   if (ctx === 'group') {
-    const cookie = req.headers.get('cookie') || ''
-    const match = cookie.match(/(?:^|; )context=([^;]+)/)
-    const requested = match ? decodeURIComponent(match[1]) : ''
     const groups = session.user?.groups ?? []
     if (!groups.includes(requested)) {
-      return new Response('Forbidden', { status: 403 })
+      return Response.json({ error: 'Forbidden' }, { status: 403 })
     }
   }
   const personal = [

--- a/app/api/v1/report/budget/route.ts
+++ b/app/api/v1/report/budget/route.ts
@@ -8,14 +8,14 @@ export async function GET(req: Request) {
   if (!session) {
     return new Response('Unauthorized', { status: 401 })
   }
+  const cookie = req.headers.get('cookie') || ''
+  const match = cookie.match(/(?:^|; )context=([^;]+)/)
+  const requested = match ? decodeURIComponent(match[1]) : 'personal'
   const ctx = getRequestContext(req)
   if (ctx === 'group') {
-    const cookie = req.headers.get('cookie') || ''
-    const match = cookie.match(/(?:^|; )context=([^;]+)/)
-    const requested = match ? decodeURIComponent(match[1]) : ''
     const groups = session.user?.groups ?? []
     if (!groups.includes(requested)) {
-      return new Response('Forbidden', { status: 403 })
+      return Response.json({ error: 'Forbidden' }, { status: 403 })
     }
   }
   const personal = [

--- a/lib/context.ts
+++ b/lib/context.ts
@@ -2,6 +2,7 @@ export type AppContext = 'personal' | 'group'
 
 export function getRequestContext(req: Request): AppContext {
   const cookie = req.headers.get('cookie') || ''
-  const match = cookie.match(/(?:^|; )context=(personal|group)/)
-  return (match ? match[1] : 'personal') as AppContext
+  const match = cookie.match(/(?:^|; )context=([^;]+)/)
+  const value = match ? decodeURIComponent(match[1]) : 'personal'
+  return value === 'personal' ? 'personal' : 'group'
 }

--- a/tests/api-routes.test.ts
+++ b/tests/api-routes.test.ts
@@ -152,7 +152,7 @@ describe('schedule API routes', () => {
 describe('budget report API route', () => {
   it('returns personal and group budget data based on context', async () => {
     vi.mocked(getServerSession).mockResolvedValue({
-      user: { id: '1', groups: ['group'] },
+      user: { id: '1', groups: ['team-a'] },
     })
     const { GET } = await import('../app/api/v1/report/budget/route')
     const resPersonal = await GET(
@@ -166,7 +166,7 @@ describe('budget report API route', () => {
     ])
 
     const resGroup = await GET(
-      new Request('http://test', { headers: { cookie: 'context=group' } }),
+      new Request('http://test', { headers: { cookie: 'context=team-a' } }),
     )
     const dataGroup = await resGroup.json()
     expect(dataGroup).toEqual([

--- a/tests/finance-auth.api.test.ts
+++ b/tests/finance-auth.api.test.ts
@@ -35,7 +35,7 @@ describe('finance report auth', () => {
     vi.mocked(getServerSession).mockResolvedValue({ user: { id: '1', groups: [] } })
     const mod: any = await import(path)
     const res = await mod.GET(
-      new Request('http://test', { headers: { cookie: 'context=group' } }),
+      new Request('http://test', { headers: { cookie: 'context=team-a' } }),
       params,
     )
     expect(res.status).toBe(403)

--- a/tests/history-detail.api.test.ts
+++ b/tests/history-detail.api.test.ts
@@ -12,7 +12,7 @@ vi.mock('next-auth', async () => {
 describe('budget history detail API route', () => {
   it('returns actions scoped to context', async () => {
     vi.mocked(getServerSession).mockResolvedValue({
-      user: { id: '1', groups: ['group'] },
+      user: { id: '1', groups: ['team-a'] },
     })
     const { GET } = await import('../app/api/v1/report/budget/history/[id]/route')
 
@@ -26,7 +26,7 @@ describe('budget history detail API route', () => {
     ])
 
     const resGroup = await GET(
-      new Request('http://test', { headers: { cookie: 'context=group' } }),
+      new Request('http://test', { headers: { cookie: 'context=team-a' } }),
       { params: { id: 'g1' } },
     )
     const dataGroup = await resGroup.json()

--- a/tests/history.api.test.ts
+++ b/tests/history.api.test.ts
@@ -12,7 +12,7 @@ vi.mock('next-auth', async () => {
 describe('budget history API route', () => {
   it('returns history scoped to context', async () => {
     vi.mocked(getServerSession).mockResolvedValue({
-      user: { id: '1', groups: ['group'] },
+      user: { id: '1', groups: ['team-a'] },
     })
     const { GET } = await import('../app/api/v1/report/budget/history/route')
     const resPersonal = await GET(
@@ -25,7 +25,7 @@ describe('budget history API route', () => {
     ])
 
     const resGroup = await GET(
-      new Request('http://test', { headers: { cookie: 'context=group' } }),
+      new Request('http://test', { headers: { cookie: 'context=team-a' } }),
     )
     const dataGroup = await resGroup.json()
     expect(dataGroup).toEqual([


### PR DESCRIPTION
## Summary
- check group membership for budget report endpoints and return JSON 403 error when unauthorized
- broaden request context detection to treat any non-personal context cookie as a group
- adjust tests to use group identifiers in context cookies

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896bf511d548326b73e6584c8012739