### PR TITLE
Handle group context in NL command

### DIFF
--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -54,8 +54,8 @@ export default function CalendarPage() {
   const handleNL = (e: React.FormEvent) => {
     e.preventDefault()
     if (!nl) return
-    const match = document.cookie.match(/(?:^|; )context=(personal|group)/)
-    const context = match ? match[1] : 'personal'
+    const match = document.cookie.match(/(?:^|; )context=([^;]+)/)
+    const context = match ? (match[1] === 'personal' ? 'personal' : 'group') : 'personal'
     socket?.send(
       JSON.stringify({
         type: 'calendar.nl.request',

--- a/tests/calendar-page.test.tsx
+++ b/tests/calendar-page.test.tsx
@@ -87,7 +87,7 @@ describe('CalendarPage', () => {
     ]);
   });
 
-  it('sends NL command', async () => {
+  it('sends NL command with personal context', async () => {
     const mutate = vi.fn();
     swrMock = vi.fn(() => ({ data: { events: [], layers: [] }, mutate }));
 
@@ -107,6 +107,30 @@ describe('CalendarPage', () => {
 
     expect(socketMock.send).toHaveBeenCalledWith(
       JSON.stringify({ type: 'calendar.nl.request', text: 'hello', context: 'personal', user: 'user1' })
+    );
+  });
+
+  it('sends NL command with group context', async () => {
+    document.cookie = 'context=team-a';
+    const mutate = vi.fn();
+    swrMock = vi.fn(() => ({ data: { events: [], layers: [] }, mutate }));
+
+    const { container } = render(<CalendarPage />);
+
+    const input = container.querySelector('input[name="nl"]') as HTMLInputElement;
+    const form = container.querySelector('form') as HTMLFormElement;
+
+    act(() => {
+      input.value = 'hi';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+
+    await act(async () => {
+      form.dispatchEvent(new Event('submit', { bubbles: true }));
+    });
+
+    expect(socketMock.send).toHaveBeenCalledWith(
+      JSON.stringify({ type: 'calendar.nl.request', text: 'hi', context: 'group', user: 'user1' })
     );
   });
 


### PR DESCRIPTION
## Summary
- Map any non-`personal` context cookie to `group` in CalendarPage
- Test NL command handling for `group` context cookies

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897bc019df88326ab0a4a3fcfa3e8b7