### PR TITLE
Handle calendar event updates in WebSocket context

### DIFF
--- a/app/socket-context.tsx
+++ b/app/socket-context.tsx
@@ -68,6 +68,9 @@ export function SocketProvider({ children }: { children: React.ReactNode }) {
             case 'calendar.event.created':
               setCalendarEvent(data);
               break;
+            case 'calendar.event.updated':
+              setCalendarEvent(data);
+              break;
             case 'finance.decision.result':
             case 'finance.explain.result':
               setFinanceUpdate(data);

--- a/tests/socket-events.test.tsx
+++ b/tests/socket-events.test.tsx
@@ -71,6 +71,21 @@ describe('socket event propagation', () => {
     expect(mutate).toHaveBeenCalled();
   });
 
+  it('refreshes calendar when an event is updated', async () => {
+    const mutate = vi.fn();
+    swrMock = vi.fn();
+    render(
+      <SocketProvider>
+        <ScheduleCalendar events={[]} layers={[]} visibleLayers={[]} mutate={mutate} />
+      </SocketProvider>
+    );
+    await act(async () => {});
+    await act(async () => {
+      onmessage?.({ data: JSON.stringify({ type: 'calendar.event.updated' }) });
+    });
+    expect(mutate).toHaveBeenCalled();
+  });
+
   it('refreshes finance data on updates', async () => {
     const mutate = vi.fn();
     swrMock = vi.fn(() => ({ data: [{ category: 'Rent', amount: 1000, costOfDeviation: 0 }], mutate }));


### PR DESCRIPTION
## Summary
- update socket context to handle `calendar.event.updated` messages
- test calendar refresh on `calendar.event.updated` socket message

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897bc02365c83269240901c49734d75