### PR TITLE
Handle SWR error on finance page

### DIFF
--- a/app/finance/page.tsx
+++ b/app/finance/page.tsx
@@ -8,7 +8,7 @@ import { useFinanceUpdates, useSocket } from '../socket-context'
 export default function FinancePage() {
   const [budget, setBudget] = useState(1000)
   const [payoffTime, setPayoffTime] = useState(12)
-  const { data, mutate } = useSWR<BudgetOption[]>(
+  const { data, error, mutate } = useSWR<BudgetOption[]>(
     `/api/v1/report/budget?budget=${budget}&payoffTime=${payoffTime}`,
     fetcher,
     { refreshInterval: 30000 },
@@ -78,6 +78,11 @@ export default function FinancePage() {
           Analyze
         </button>
       </div>
+      {error && (
+        <p role="alert" className="mb-4 text-red-500">
+          Failed to load budget options.
+        </p>
+      )}
       <div className="grid gap-4 md:grid-cols-2">
         {ranked.map((option, idx) => {
           const label = String.fromCharCode(65 + idx)

--- a/tests/finance-page.test.tsx
+++ b/tests/finance-page.test.tsx
@@ -100,5 +100,12 @@ describe('FinancePage', () => {
     act(() => { analyzeBtn.click(); });
     expect(mutate).toHaveBeenCalled();
   });
+
+  it('displays an error message when the fetch fails', () => {
+    const mutate = vi.fn();
+    swrMock = vi.fn(() => ({ error: new Error('Bad request'), mutate }));
+    const { container } = render(<FinancePage />);
+    expect(container.textContent).toContain('Failed to load budget options.');
+  });
 });
 


### PR DESCRIPTION
## Summary
- show a visible error message when the finance budget request fails
- add a failing-fetch test verifying the error is rendered

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897fccc10048326a1b440497476a262