### PR TITLE
feat: add shared event tooltip

### DIFF
--- a/app/components/ScheduleCalendar.tsx
+++ b/app/components/ScheduleCalendar.tsx
@@ -7,6 +7,7 @@ import timeGridPlugin from '@fullcalendar/timegrid'
 import interactionPlugin, { EventDropArg, DateClickArg } from '@fullcalendar/interaction'
 import { EventContentArg, EventMountArg } from '@fullcalendar/core'
 import { useCalendarEvents, useTaskStatus } from '../socket-context'
+import SharedEventTooltip from './SharedEventTooltip'
 
 interface Layer {
   id: string
@@ -59,8 +60,6 @@ export default function ScheduleCalendar({ events, layers, visibleLayers, mutate
 
   const handleEventMount = (info: EventMountArg) => {
     const shared = info.event.extendedProps.shared
-    const invitees: string[] = info.event.extendedProps.invitees || []
-    const permissions: string[] = info.event.extendedProps.permissions || []
     if (info.view.type === 'dayGridMonth') {
       info.el.style.display = 'none'
       return
@@ -72,9 +71,6 @@ export default function ScheduleCalendar({ events, layers, visibleLayers, mutate
       icon.className = 'mr-1'
       info.el.prepend(icon)
     }
-    if (invitees.length || permissions.length) {
-      info.el.title = `Invitees: ${invitees.join(', ')}\nPermissions: ${permissions.join(', ')}`
-    }
     const color = info.event.backgroundColor || info.event.extendedProps.backgroundColor
     if (color) {
       info.el.style.backgroundColor = color
@@ -85,12 +81,22 @@ export default function ScheduleCalendar({ events, layers, visibleLayers, mutate
   const renderEventContent = (arg: EventContentArg) => {
     if (arg.view.type === 'dayGridMonth') return null
     const shared = arg.event.extendedProps.shared
-    return (
+    const invitees: string[] = arg.event.extendedProps.invitees || []
+    const permissions: string[] = arg.event.extendedProps.permissions || []
+    const content = (
       <div className="flex items-center">
         {shared && <span className="mr-1">👥</span>}
         <span>{arg.event.title}</span>
       </div>
     )
+    if (invitees.length || permissions.length) {
+      return (
+        <SharedEventTooltip invitees={invitees} permissions={permissions}>
+          {content}
+        </SharedEventTooltip>
+      )
+    }
+    return content
   }
 
   const renderDayCell = (arg: DayCellContentArg) => {

--- a/app/components/SharedEventTooltip.tsx
+++ b/app/components/SharedEventTooltip.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import React, { useState } from 'react'
+
+interface SharedEventTooltipProps {
+  children: React.ReactNode
+  invitees?: string[]
+  permissions?: string[]
+}
+
+export default function SharedEventTooltip({ children, invitees = [], permissions = [] }: SharedEventTooltipProps) {
+  const [visible, setVisible] = useState(false)
+  const content = `Invitees: ${invitees.join(', ') || 'None'}\nPermissions: ${permissions.join(', ') || 'None'}`
+  return (
+    <div
+      className="relative inline-block"
+      onMouseEnter={() => setVisible(true)}
+      onMouseLeave={() => setVisible(false)}
+      onFocus={() => setVisible(true)}
+      onBlur={() => setVisible(false)}
+      tabIndex={0}
+    >
+      {children}
+      {visible && (
+        <div
+          role="tooltip"
+          className="absolute z-10 p-2 text-xs text-white bg-gray-800 rounded shadow whitespace-pre-line"
+        >
+          {content}
+        </div>
+      )}
+    </div>
+  )
+}
+

--- a/tests/schedule-accessibility.test.tsx
+++ b/tests/schedule-accessibility.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { act } from 'react-dom/test-utils'
+import ScheduleCalendar from '../app/components/ScheduleCalendar'
+
+vi.mock('../app/socket-context', () => ({
+  __esModule: true,
+  useCalendarEvents: () => null,
+  useTaskStatus: () => null,
+}))
+
+vi.mock('@fullcalendar/react', () => ({
+  __esModule: true,
+  default: (props: any) => {
+    const arg = {
+      event: {
+        title: 'Meeting',
+        extendedProps: {
+          invitees: ['Alice', 'Bob'],
+          permissions: ['view', 'edit'],
+          shared: true,
+        },
+      },
+      view: { type: 'timeGridWeek' },
+    }
+    const node = props.eventContent(arg)
+    return React.createElement('div', null, node)
+  },
+}))
+
+function render(ui: React.ReactElement) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = ReactDOM.createRoot(container)
+  act(() => {
+    root.render(ui)
+  })
+  return { container, root }
+}
+
+describe('ScheduleCalendar accessibility', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('shows tooltip with invitees and permissions', () => {
+    render(<ScheduleCalendar events={[]} layers={[]} visibleLayers={[]} mutate={() => {}} />)
+    const wrapper = document.querySelector('div[tabindex="0"]') as HTMLElement
+    act(() => {
+      wrapper.focus()
+    })
+    const tooltip = document.querySelector('[role="tooltip"]') as HTMLElement
+    expect(tooltip).toBeTruthy()
+    expect(tooltip.textContent).toContain('Invitees: Alice, Bob')
+    expect(tooltip.textContent).toContain('Permissions: view, edit')
+  })
+})
+


### PR DESCRIPTION
## Summary
- add `SharedEventTooltip` component to show invitees and permissions on hover/focus
- integrate tooltip in `ScheduleCalendar` instead of `title` attribute
- test tooltip accessibility

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897fcccb7dc8326a7ce4dfa95b92b72