### PR TITLE
feat(auth): add github oauth provider

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,5 +1,6 @@
 import NextAuth, { type NextAuthOptions } from 'next-auth'
 import CredentialsProvider from 'next-auth/providers/credentials'
+import GitHubProvider from 'next-auth/providers/github'
 
 export const authOptions: NextAuthOptions = {
   providers: [
@@ -18,6 +19,10 @@ export const authOptions: NextAuthOptions = {
         return null
       },
     }),
+    GitHubProvider({
+      clientId: process.env.GITHUB_ID!,
+      clientSecret: process.env.GITHUB_SECRET!,
+    }),
   ],
   session: {
     strategy: 'jwt',
@@ -26,6 +31,9 @@ export const authOptions: NextAuthOptions = {
     async session({ session, token }) {
       if (session.user && token.sub) {
         session.user.id = token.sub as string
+      }
+      if (token.accessToken) {
+        ;(session as any).accessToken = token.accessToken as string
       }
       return session
     },

--- a/tests/auth-route.test.ts
+++ b/tests/auth-route.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeAll } from 'vitest'
 
 vi.mock('next-auth', () => {
   return {
@@ -8,7 +8,7 @@ vi.mock('next-auth', () => {
         const url = new URL(req.url)
         if (req.method === 'POST' && url.pathname.endsWith('/callback/credentials')) {
           const { username, password } = await req.json()
-          const provider = options.providers[0]
+          const provider = options.providers.find((p: any) => p.id === 'credentials')
           const user = await provider.options.authorize({ username, password })
           if (!user) {
             return new Response('Unauthorized', { status: 401 })
@@ -22,13 +22,34 @@ vi.mock('next-auth', () => {
             headers: { 'Content-Type': 'application/json' },
           })
         }
+        if (req.method === 'GET' && url.pathname.endsWith('/callback/github')) {
+          const provider = options.providers.find((p: any) => p.id === 'github')
+          const user = { id: '2', name: 'GitHub User' }
+          const session = await options.callbacks.session({
+            session: { user },
+            token: { sub: user.id, accessToken: 'gh-token-123' },
+          })
+          return new Response(JSON.stringify(session), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          })
+        }
         return new Response(null, { status: 404 })
       }
     },
   }
 })
 
-import { POST } from '../app/api/auth/[...nextauth]/route'
+let POST: any
+let GET: any
+
+beforeAll(async () => {
+  process.env.GITHUB_ID = 'id'
+  process.env.GITHUB_SECRET = 'secret'
+  const route = await import('../app/api/auth/[...nextauth]/route')
+  POST = route.POST
+  GET = route.GET
+})
 
 describe('auth route', () => {
   it('returns session with user id for valid credentials', async () => {
@@ -51,6 +72,17 @@ describe('auth route', () => {
     })
     const res = await POST(req)
     expect(res.status).toBe(401)
+  })
+
+  it('returns session with user id and access token for GitHub OAuth', async () => {
+    const req = new Request('http://localhost/api/auth/callback/github?code=abc', {
+      method: 'GET',
+    })
+    const res = await GET(req)
+    expect(res.status).toBe(200)
+    const session = await res.json()
+    expect(session.user.id).toBe('2')
+    expect(session.accessToken).toBe('gh-token-123')
   })
 })
 


### PR DESCRIPTION
## Summary
- add GitHub OAuth provider to NextAuth using env vars
- expose access token in session callback
- test auth route with mocked GitHub provider

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898023ae9148326ae7cf00dd8a95d9a