### PR TITLE
Retry task status websocket with exponential backoff

### DIFF
--- a/lib/taskCascadence.ts
+++ b/lib/taskCascadence.ts
@@ -12,15 +12,26 @@ type Callback = (event: TaskStatusEvent) => void
 let ws: WebSocket | null = null
 const callbacks = new Set<Callback>()
 let latestStatus: TaskStatusEvent | null = null
+let reconnectAttempts = 0
+let reconnectTimeout: ReturnType<typeof setTimeout> | null = null
+let shouldReconnect = true
 
 function ensureConnection() {
   if (ws || typeof window === 'undefined') return
+  if (reconnectTimeout) {
+    clearTimeout(reconnectTimeout)
+    reconnectTimeout = null
+  }
   const url = process.env.NEXT_PUBLIC_TASK_CASCADENCE_WS_URL
   if (!url) {
     console.error('TaskCascadence WebSocket URL is not defined')
     return
   }
+  shouldReconnect = true
   ws = new WebSocket(url)
+  ws.onopen = () => {
+    reconnectAttempts = 0
+  }
   ws.onmessage = (event: MessageEvent) => {
     try {
       const data = JSON.parse(event.data)
@@ -34,6 +45,10 @@ function ensureConnection() {
   }
   ws.onclose = () => {
     ws = null
+    if (!shouldReconnect) return
+    const delay = Math.min(10000, 1000 * 2 ** reconnectAttempts)
+    reconnectAttempts += 1
+    reconnectTimeout = setTimeout(ensureConnection, delay)
   }
 }
 
@@ -43,8 +58,14 @@ export function subscribeToTaskStatus(callback: Callback) {
   return () => {
     callbacks.delete(callback)
     if (!callbacks.size && ws) {
+      shouldReconnect = false
       ws.close()
       ws = null
+      if (reconnectTimeout) {
+        clearTimeout(reconnectTimeout)
+        reconnectTimeout = null
+      }
+      reconnectAttempts = 0
     }
   }
 }

--- a/tests/task-status-reconnect.test.tsx
+++ b/tests/task-status-reconnect.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+describe('Task status websocket reconnection', () => {
+  const originalEnv = process.env.NEXT_PUBLIC_TASK_CASCADENCE_WS_URL
+
+  beforeEach(() => {
+    vi.resetModules()
+    process.env.NEXT_PUBLIC_TASK_CASCADENCE_WS_URL = 'ws://example.com'
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    if (originalEnv === undefined) {
+      delete process.env.NEXT_PUBLIC_TASK_CASCADENCE_WS_URL
+    } else {
+      process.env.NEXT_PUBLIC_TASK_CASCADENCE_WS_URL = originalEnv
+    }
+    vi.useRealTimers()
+  })
+
+  it('reconnects with exponential backoff when the socket closes', async () => {
+    vi.useFakeTimers()
+    const wsInstances: any[] = []
+
+    class MockWebSocket {
+      onopen: ((ev: any) => void) | null = null
+      onclose: ((ev: any) => void) | null = null
+      onmessage: ((ev: any) => void) | null = null
+      close = vi.fn()
+      constructor() {
+        wsInstances.push(this)
+      }
+    }
+
+    const wsMock = vi.fn(() => new MockWebSocket() as unknown as WebSocket)
+    const setTimeoutSpy = vi.spyOn(global, 'setTimeout')
+    vi.stubGlobal('WebSocket', wsMock)
+
+    const { subscribeToTaskStatus } = await import('../lib/taskCascadence')
+
+    const unsubscribe = subscribeToTaskStatus(() => {})
+
+    expect(wsMock).toHaveBeenCalledTimes(1)
+
+    const first = wsInstances[0]
+    first.onclose?.({})
+
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 1000)
+
+    await vi.runOnlyPendingTimersAsync()
+
+    expect(wsMock).toHaveBeenCalledTimes(2)
+
+    const second = wsInstances[1]
+    second.onclose?.({})
+
+    expect(setTimeoutSpy).toHaveBeenLastCalledWith(expect.any(Function), 2000)
+
+    unsubscribe()
+  })
+})
+


### PR DESCRIPTION
## Summary
- add exponential backoff reconnect logic to task status WebSocket
- test task status WebSocket reconnection behavior

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68980239bc1c83268077edffb5f2d26a