### PR TITLE
Handle non-OK fetch responses

### DIFF
--- a/lib/swr.tsx
+++ b/lib/swr.tsx
@@ -2,7 +2,13 @@
 import React from 'react'
 import { SWRConfig } from 'swr'
 
-export const fetcher = (url: string) => fetch(url).then(res => res.json())
+export const fetcher = (url: string) =>
+  fetch(url).then(res => {
+    if (!res.ok) {
+      throw new Error(`${res.status} ${res.statusText}`)
+    }
+    return res.json()
+  })
 
 function localStorageProvider() {
   if (typeof window === 'undefined') return new Map()

--- a/tests/swr-cache.test.tsx
+++ b/tests/swr-cache.test.tsx
@@ -56,4 +56,29 @@ describe('SWR local cache', () => {
     expect(container2.textContent).toBe('server')
     expect(fetchSpy2).toHaveBeenCalledTimes(0)
   })
+
+  it('bubbles non-OK responses as errors', async () => {
+    const key = '/api/error'
+    const fetchMock = vi.fn(() =>
+      Promise.resolve(
+        new Response('fail', { status: 500, statusText: 'Internal Server Error' })
+      )
+    )
+    vi.spyOn(globalThis, 'fetch').mockImplementation(fetchMock as any)
+
+    function Comp() {
+      const { error } = useSWR(key)
+      return <div>{error ? error.message : ''}</div>
+    }
+
+    const { container } = render(
+      <SWRProvider>
+        <Comp />
+      </SWRProvider>
+    )
+
+    await act(async () => {})
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(container.textContent).toContain('Internal Server Error')
+  })
 })


### PR DESCRIPTION
## Summary
- Throw errors with status details when fetch responses are not OK
- Add test to ensure non-OK responses surface as errors

## Testing
- `npm test tests/swr-cache.test.tsx`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bab4618088326a8ebb344b7708137