### PR TITLE
feat: add event owner to calendar events

### DIFF
--- a/app/api/schedule/store.ts
+++ b/app/api/schedule/store.ts
@@ -16,6 +16,7 @@ export interface CalendarEvent {
   shared?: boolean
   invitees?: string[]
   permissions?: string[]
+  owner?: string
 }
 
 interface CalendarData {
@@ -68,7 +69,7 @@ export async function getEvent(id: string): Promise<CalendarEvent | undefined> {
 
 export function validateEvent(data: any): CalendarEvent {
   if (!data || typeof data !== 'object') throw new Error('Invalid payload')
-  const { id, title, start, end, layer, shared, invitees, permissions } = data
+  const { id, title, start, end, layer, shared, invitees, permissions, owner } = data
   if (typeof id !== 'string' || typeof start !== 'string') {
     throw new Error('id and start are required')
   }
@@ -90,7 +91,10 @@ export function validateEvent(data: any): CalendarEvent {
   if (permissions !== undefined && !Array.isArray(permissions)) {
     throw new Error('permissions must be array')
   }
-  return { id, title, start, end, layer, shared, invitees, permissions }
+  if (owner !== undefined && typeof owner !== 'string') {
+    throw new Error('owner must be string')
+  }
+  return { id, title, start, end, layer, shared, invitees, permissions, owner }
 }
 
 export function validateEventPatch(data: any): Partial<CalendarEvent> {
@@ -123,6 +127,10 @@ export function validateEventPatch(data: any): Partial<CalendarEvent> {
   if (data.permissions !== undefined) {
     if (!Array.isArray(data.permissions)) throw new Error('permissions must be array')
     result.permissions = data.permissions
+  }
+  if (data.owner !== undefined) {
+    if (typeof data.owner !== 'string') throw new Error('owner must be string')
+    result.owner = data.owner
   }
   if (data.id !== undefined) {
     throw new Error('id cannot be updated')

--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -23,6 +23,7 @@ interface Event {
   shared?: boolean
   invitees?: string[]
   permissions?: string[]
+  owner?: string
 }
 
 interface CalendarData {
@@ -75,7 +76,7 @@ export default function CalendarPage() {
     const res = await fetch('/api/schedule', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ id, title, start, end, layer, shared })
+      body: JSON.stringify({ id, title, start, end, layer, shared, owner: session?.user?.id })
     })
     if (!res.ok) {
       let message = 'Failed to create event'

--- a/app/components/ScheduleCalendar.tsx
+++ b/app/components/ScheduleCalendar.tsx
@@ -24,6 +24,7 @@ interface Event {
   shared?: boolean
   invitees?: string[]
   permissions?: string[]
+  owner?: string
 }
 
 interface ScheduleCalendarProps {
@@ -83,9 +84,12 @@ export default function ScheduleCalendar({ events, layers, visibleLayers, mutate
     const shared = arg.event.extendedProps.shared
     const invitees: string[] = arg.event.extendedProps.invitees || []
     const permissions: string[] = arg.event.extendedProps.permissions || []
+    const owner: string | undefined = arg.event.extendedProps.owner
+    const initials = owner?.slice(0, 2).toUpperCase()
     const content = (
       <div className="flex items-center">
         {shared && <span className="mr-1">👥</span>}
+        {initials && <span className="mr-1">{initials}</span>}
         <span>{arg.event.title}</span>
       </div>
     )
@@ -114,6 +118,7 @@ export default function ScheduleCalendar({ events, layers, visibleLayers, mutate
                   style={{ backgroundColor: e.backgroundColor, border: e.shared ? '1px solid black' : 'none' }}
                 />
                 {e.shared && <span className="mr-1">👥</span>}
+                {e.owner && <span className="mr-1">{e.owner.slice(0, 2).toUpperCase()}</span>}
                 {e.title || '(no title)'}
               </li>
             ))}

--- a/tests/calendar-page.test.tsx
+++ b/tests/calendar-page.test.tsx
@@ -197,6 +197,7 @@ describe('CalendarPage', () => {
     const body = JSON.parse(fetchMock.mock.calls[0][1].body);
     expect(body.id).toBe('uuid-1');
     expect(body.shared).toBe(true);
+    expect(body.owner).toBe('user1');
   });
 
   it('renders shared events with distinctive styling', () => {
@@ -218,5 +219,25 @@ describe('CalendarPage', () => {
 
     expect(el.classList.contains('border-dashed')).toBe(true);
     expect(el.firstChild?.textContent).toBe('👥');
+  });
+
+  it('renders owner initials on events', () => {
+    const mutate = vi.fn();
+    swrMock = vi.fn(() => ({
+      data: { events: [{ id: '1', title: 't', start: '2023-01-01', owner: 'user1' }], layers: [] }, mutate },
+    ));
+
+    render(<CalendarPage />);
+
+    const arg = {
+      event: { title: 't', extendedProps: { owner: 'user1' } },
+      view: { type: 'timeGridWeek' },
+    } as any;
+    const result = calendarProps.eventContent(arg);
+    const container = document.createElement('div');
+    act(() => {
+      ReactDOM.createRoot(container).render(result as any);
+    });
+    expect(container.textContent).toContain('US');
   });
 });


### PR DESCRIPTION
## Summary
- add `owner` to stored calendar events and validations
- include session user as event owner when creating
- show event owner's initials in calendar views
- test event owner display and creation payload

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bab45a5d4832693092964d04b45b7