### PR TITLE
feat: add groupId to calendar events

### DIFF
--- a/app/api/schedule/store.ts
+++ b/app/api/schedule/store.ts
@@ -17,6 +17,7 @@ export interface CalendarEvent {
   invitees?: string[]
   permissions?: string[]
   owner?: string
+  groupId?: string
 }
 
 interface CalendarData {
@@ -33,7 +34,18 @@ async function read(): Promise<CalendarData> {
     const text = await fs.readFile(dataFile, 'utf8')
     const data = JSON.parse(text)
     return {
-      events: data.events || [],
+      events: (data.events || []).map((e: any) => ({
+        id: e.id,
+        title: e.title,
+        start: e.start,
+        end: e.end,
+        layer: e.layer,
+        shared: e.shared,
+        invitees: e.invitees,
+        permissions: e.permissions,
+        owner: e.owner,
+        groupId: e.groupId
+      })),
       layers: data.layers || []
     }
   } catch (err: any) {
@@ -51,11 +63,13 @@ async function write(data: CalendarData): Promise<void> {
 }
 
 export async function getData(): Promise<CalendarData> {
-  return read()
+  const data = await read()
+  return { events: data.events, layers: data.layers }
 }
 
 export async function getEvents(): Promise<CalendarEvent[]> {
-  return (await read()).events
+  const data = await getData()
+  return data.events
 }
 
 export async function getLayers(): Promise<CalendarLayer[]> {
@@ -69,7 +83,18 @@ export async function getEvent(id: string): Promise<CalendarEvent | undefined> {
 
 export function validateEvent(data: any): CalendarEvent {
   if (!data || typeof data !== 'object') throw new Error('Invalid payload')
-  const { id, title, start, end, layer, shared, invitees, permissions, owner } = data
+  const {
+    id,
+    title,
+    start,
+    end,
+    layer,
+    shared,
+    invitees,
+    permissions,
+    owner,
+    groupId
+  } = data
   if (typeof id !== 'string' || typeof start !== 'string') {
     throw new Error('id and start are required')
   }
@@ -94,7 +119,21 @@ export function validateEvent(data: any): CalendarEvent {
   if (owner !== undefined && typeof owner !== 'string') {
     throw new Error('owner must be string')
   }
-  return { id, title, start, end, layer, shared, invitees, permissions, owner }
+  if (groupId !== undefined && typeof groupId !== 'string') {
+    throw new Error('groupId must be string')
+  }
+  return {
+    id,
+    title,
+    start,
+    end,
+    layer,
+    shared,
+    invitees,
+    permissions,
+    owner,
+    groupId
+  }
 }
 
 export function validateEventPatch(data: any): Partial<CalendarEvent> {
@@ -131,6 +170,10 @@ export function validateEventPatch(data: any): Partial<CalendarEvent> {
   if (data.owner !== undefined) {
     if (typeof data.owner !== 'string') throw new Error('owner must be string')
     result.owner = data.owner
+  }
+  if (data.groupId !== undefined) {
+    if (typeof data.groupId !== 'string') throw new Error('groupId must be string')
+    result.groupId = data.groupId
   }
   if (data.id !== undefined) {
     throw new Error('id cannot be updated')


### PR DESCRIPTION
## Summary
- add `groupId` support to calendar events
- persist `groupId` in schedule store read helpers
- validate and patch `groupId` when creating or updating events

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689be22259c48326a81c5d773c095fff