### PR TITLE
Use session token for WebSocket auth

### DIFF
--- a/tests/socket-events.test.tsx
+++ b/tests/socket-events.test.tsx
@@ -3,6 +3,11 @@ import ReactDOM from 'react-dom/client';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { act } from 'react-dom/test-utils';
 
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: { accessToken: 'test-token' } }),
+  signIn: vi.fn(),
+}));
+
 import { SocketProvider } from '../app/socket-context';
 import ScheduleCalendar from '../app/components/ScheduleCalendar';
 import FinancePage from '../app/finance/page';

--- a/tests/socket-provider.test.tsx
+++ b/tests/socket-provider.test.tsx
@@ -1,8 +1,14 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { SocketProvider, useSocket, useCalendarEvents, useFinanceUpdates } from '../app/socket-context';
 import { act } from 'react-dom/test-utils';
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: { accessToken: 'test-token' } }),
+  signIn: vi.fn(),
+}));
+
+import { SocketProvider, useSocket, useCalendarEvents, useFinanceUpdates } from '../app/socket-context';
 
 function render(ui: React.ReactElement) {
   const container = document.createElement('div');
@@ -50,7 +56,7 @@ describe('SocketProvider', () => {
 
     await act(async () => {});
 
-    expect(wsMock).toHaveBeenCalledWith('ws://localhost:3001');
+    expect(wsMock).toHaveBeenCalledWith('ws://localhost:3001?token=test-token');
     expect(socket).toBe(wsInstance);
   });
 


### PR DESCRIPTION
## Summary
- include access token from session when creating WebSocket connection
- prompt user re-login when WebSocket closes with unauthorized code
- adjust tests to mock session token usage

## Testing
- `npx vitest run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cd70528a48326baa98650f897f1a4