### PR TITLE
feat(ws): forward session token

### DIFF
--- a/app/api/schedule/route.ts
+++ b/app/api/schedule/route.ts
@@ -68,7 +68,7 @@ export async function POST(req: Request) {
     const event =
       ctx === 'group' ? { ...baseEvent, groupId: groupId! } : baseEvent
     await addEvent(event)
-    sendWsMessage({ type: 'calendar.event.created', event })
+    sendWsMessage({ type: 'calendar.event.created', event }, (session as any).accessToken)
     return Response.json({ success: true })
   } catch (e: any) {
     return Response.json({ error: e.message }, { status: 400 })

--- a/app/api/task/[id]/route.ts
+++ b/app/api/task/[id]/route.ts
@@ -67,7 +67,10 @@ export async function PATCH(
     const patch = validateEventPatch(body)
     await updateEvent(params.id, patch)
     const updated = { ...existing, ...patch }
-    sendWsMessage({ type: 'calendar.event.updated', event: updated })
+    sendWsMessage(
+      { type: 'calendar.event.updated', event: updated },
+      (session as any).accessToken,
+    )
     return Response.json({ success: true })
   } catch (e: any) {
     return Response.json({ error: e.message }, { status: 400 })

--- a/tests/calendar-websocket.api.test.ts
+++ b/tests/calendar-websocket.api.test.ts
@@ -39,7 +39,10 @@ describe('calendar websocket notifications', () => {
     process.env.SCHEDULE_DATA_FILE = file
     await fs.writeFile(file, JSON.stringify({ events: [], layers: [] }))
 
-    vi.mocked(getServerSession).mockResolvedValue({ user: { id: '1' } })
+    vi.mocked(getServerSession).mockResolvedValue({
+      user: { id: '1' },
+      accessToken: 'token123',
+    })
 
     const send = vi.fn()
     const wsInstance: any = { send, readyState: 1, OPEN: 1 }
@@ -63,6 +66,7 @@ describe('calendar websocket notifications', () => {
       type: 'calendar.event.created',
       event,
     })
+    expect(wsMock).toHaveBeenCalledWith('ws://test?token=token123')
 
     const patchReq = new Request('http://test', {
       method: 'PATCH',


### PR DESCRIPTION
## Summary
- allow ws-server to append an optional session token when establishing WebSocket connections
- forward the session token from schedule and task API routes when emitting calendar events
- test WebSocket notifications with tokenized connections

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cd706381083269ce64cd2ec0a6a14