### PR TITLE
feat: add event density visualization

### DIFF
--- a/app/components/ScheduleCalendar.tsx
+++ b/app/components/ScheduleCalendar.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState, useMemo } from 'react'
 import FullCalendar from '@fullcalendar/react'
 import dayGridPlugin, { DayCellContentArg } from '@fullcalendar/daygrid'
 import timeGridPlugin from '@fullcalendar/timegrid'
@@ -59,6 +59,20 @@ export default function ScheduleCalendar({ events, layers, visibleLayers, mutate
       }
     })
 
+  const eventsByDate = useMemo(() => {
+    return filtered.reduce<Record<string, Event[]>>((acc, e) => {
+      const date = e.start.split('T')[0]
+      acc[date] = acc[date] ? [...acc[date], e] : [e]
+      return acc
+    }, {})
+  }, [filtered])
+
+  const getColorClass = (count: number) => {
+    if (count === 0) return ''
+    const classes = ['bg-blue-100', 'bg-blue-200', 'bg-blue-300', 'bg-blue-400', 'bg-blue-500']
+    return classes[Math.min(count, classes.length) - 1]
+  }
+
   const handleEventMount = (info: EventMountArg) => {
     const shared = info.event.extendedProps.shared
     if (info.view.type === 'dayGridMonth') {
@@ -105,10 +119,12 @@ export default function ScheduleCalendar({ events, layers, visibleLayers, mutate
 
   const renderDayCell = (arg: DayCellContentArg) => {
     const dateStr = arg.date.toISOString().split('T')[0]
-    const dayEvents = filtered.filter(e => e.start.split('T')[0] === dateStr)
+    const dayEvents = eventsByDate[dateStr] || []
+    const count = dayEvents.length
+    const colorClass = getColorClass(count)
     if (selectedDate === dateStr) {
       return (
-        <div>
+        <div className={`h-full w-full ${colorClass}`} title={`${count} events`}>
           <div className="fc-daygrid-day-number">{arg.dayNumberText}</div>
           <ul className="mt-1 text-xs">
             {dayEvents.map(e => (
@@ -127,7 +143,7 @@ export default function ScheduleCalendar({ events, layers, visibleLayers, mutate
       )
     }
     return (
-      <div>
+      <div className={`h-full w-full ${colorClass}`} title={`${count} events`}>
         <div className="fc-daygrid-day-number">{arg.dayNumberText}</div>
         <div className="flex flex-wrap gap-1 mt-1">
           {dayEvents.map(e => (
@@ -157,21 +173,31 @@ export default function ScheduleCalendar({ events, layers, visibleLayers, mutate
   }
 
   return (
-    <FullCalendar
-      plugins={[dayGridPlugin, timeGridPlugin, interactionPlugin]}
-      initialView="dayGridMonth"
-      headerToolbar={{
-        left: 'prev,next today',
-        center: 'title',
-        right: 'dayGridMonth,timeGridWeek,timeGridDay'
-      }}
-      events={filtered}
-      editable
-      eventDrop={handleDrop}
-      eventDidMount={handleEventMount}
-      eventContent={renderEventContent}
-      dayCellContent={renderDayCell}
-      dateClick={handleDateClick}
-    />
+    <div>
+      <FullCalendar
+        plugins={[dayGridPlugin, timeGridPlugin, interactionPlugin]}
+        initialView="dayGridMonth"
+        headerToolbar={{
+          left: 'prev,next today',
+          center: 'title',
+          right: 'dayGridMonth,timeGridWeek,timeGridDay'
+        }}
+        events={filtered}
+        editable
+        eventDrop={handleDrop}
+        eventDidMount={handleEventMount}
+        eventContent={renderEventContent}
+        dayCellContent={renderDayCell}
+        dateClick={handleDateClick}
+      />
+      <div className="flex items-center gap-2 mt-2 text-xs" aria-label="Event count legend">
+        {[1, 2, 3, 4, 5].map(n => (
+          <div key={n} className="flex items-center gap-1">
+            <span className={`w-3 h-3 rounded-sm ${getColorClass(n)}`} />
+            <span>{n}{n === 5 ? '+' : ''}</span>
+          </div>
+        ))}
+      </div>
+    </div>
   )
 }


### PR DESCRIPTION
## Summary
- compute daily event counts
- color calendar day cells by event density and add legend

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d3b5318fc8326a394201f981baeb4