### PR TITLE
feat(finance): highlight best option

### DIFF
--- a/app/finance/page.tsx
+++ b/app/finance/page.tsx
@@ -94,11 +94,18 @@ export default function FinancePage() {
                 isBest ? 'border-green-500 bg-green-50' : ''
               }`}
             >
-              <div className="font-bold mb-2">
-                Option {label} - {option.category}
+              <div className="font-bold mb-2 flex items-center justify-between">
+                <span>
+                  Option {label} - {option.category}
+                </span>
+                {isBest && (
+                  <span className="ml-2 bg-green-500 text-white text-xs px-2 py-0.5 rounded">
+                    Best
+                  </span>
+                )}
               </div>
               <p>Amount: ${option.amount}</p>
-              <p>Cost of deviation: ${option.costOfDeviation}</p>
+              {!isBest && <p>Cost of deviation: ${option.costOfDeviation}</p>}
               <button
                 className="mt-2 text-blue-500 underline"
                 onClick={() => {

--- a/tests/finance-page.test.tsx
+++ b/tests/finance-page.test.tsx
@@ -49,6 +49,10 @@ describe('FinancePage', () => {
     expect(cards[0].className).toContain('border-green-500');
     expect(cards[0].className).toContain('bg-green-50');
     expect(cards[1].className).not.toContain('border-green-500');
+    expect(cards[0].textContent).toContain('Best');
+    expect(cards[0].textContent).not.toContain('Cost of deviation');
+    const costInfo = cards[1].querySelector('p:nth-of-type(2)') as HTMLParagraphElement;
+    expect(costInfo.textContent).toMatch(/Cost of deviation:/);
     const viewBtn = cards[0].querySelector('button') as HTMLButtonElement;
     act(() => { viewBtn.click(); });
     expect(send).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- show a "Best" badge on the lowest cost finance option
- hide cost-of-deviation on the best option while keeping it on others
- test coverage for best option badge and cost display

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d3b53c49c8326b7ac6e86ee40f9c0