### PR TITLE
feat: highlight best finance option

### DIFF
--- a/app/finance/page.tsx
+++ b/app/finance/page.tsx
@@ -99,8 +99,11 @@ export default function FinancePage() {
                   Option {label} - {option.category}
                 </span>
                 {isBest && (
-                  <span className="ml-2 bg-green-500 text-white text-xs px-2 py-0.5 rounded">
-                    Best
+                  <span
+                    aria-label="best option"
+                    className="ml-2 flex items-center bg-green-500 text-white text-xs px-2 py-0.5 rounded"
+                  >
+                    <span className="mr-1">⭐</span>Best
                   </span>
                 )}
               </div>

--- a/tests/finance-page.test.tsx
+++ b/tests/finance-page.test.tsx
@@ -50,6 +50,7 @@ describe('FinancePage', () => {
     expect(cards[0].className).toContain('bg-green-50');
     expect(cards[1].className).not.toContain('border-green-500');
     expect(cards[0].textContent).toContain('Best');
+    expect(cards[0].textContent).toContain('⭐');
     expect(cards[0].textContent).not.toContain('Cost of deviation');
     const costInfo = cards[1].querySelector('p:nth-of-type(2)') as HTMLParagraphElement;
     expect(costInfo.textContent).toMatch(/Cost of deviation:/);


### PR DESCRIPTION
## Summary
- Add star-styled "Best" badge to the lowest-cost finance option card
- Keep cost-of-deviation visible only on non-optimal cards
- Update FinancePage test to assert badge rendering

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689dfc61bfc88326973421e36e583a36