### PR TITLE
Refactor request context parsing into helper

### DIFF
--- a/app/api/v1/report/budget/history/[id]/route.ts
+++ b/app/api/v1/report/budget/history/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '../../../../../auth/[...nextauth]/route'
-import { getRequestContext } from '../../../../../../../lib/context'
+import { getContextAndGroupId } from '../../../../../../../lib/context-utils'
 
 type Action = { id: string; description: string }
 
@@ -35,13 +35,10 @@ export async function GET(
   if (!session) {
     return new Response('Unauthorized', { status: 401 })
   }
-  const cookie = req.headers.get('cookie') || ''
-  const match = cookie.match(/(?:^|; )context=([^;]+)/)
-  const requested = match ? decodeURIComponent(match[1]) : 'personal'
-  const ctx = getRequestContext(req)
+  const { context: ctx, groupId } = getContextAndGroupId(req)
   if (ctx === 'group') {
     const groups = session.user?.groups ?? []
-    if (!groups.includes(requested)) {
+    if (!groupId || !groups.includes(groupId)) {
       return Response.json({ error: 'Forbidden' }, { status: 403 })
     }
   }

--- a/app/api/v1/report/budget/history/route.ts
+++ b/app/api/v1/report/budget/history/route.ts
@@ -1,20 +1,17 @@
 import { NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '../../../../auth/[...nextauth]/route'
-import { getRequestContext } from '../../../../../../lib/context'
+import { getContextAndGroupId } from '../../../../../../lib/context-utils'
 
 export async function GET(req: Request) {
   const session = await getServerSession(authOptions)
   if (!session) {
     return new Response('Unauthorized', { status: 401 })
   }
-  const cookie = req.headers.get('cookie') || ''
-  const match = cookie.match(/(?:^|; )context=([^;]+)/)
-  const requested = match ? decodeURIComponent(match[1]) : 'personal'
-  const ctx = getRequestContext(req)
+  const { context: ctx, groupId } = getContextAndGroupId(req)
   if (ctx === 'group') {
     const groups = session.user?.groups ?? []
-    if (!groups.includes(requested)) {
+    if (!groupId || !groups.includes(groupId)) {
       return Response.json({ error: 'Forbidden' }, { status: 403 })
     }
   }

--- a/app/api/v1/report/budget/route.ts
+++ b/app/api/v1/report/budget/route.ts
@@ -1,20 +1,17 @@
 import { NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '../../../auth/[...nextauth]/route'
-import { getRequestContext } from '../../../../../lib/context'
+import { getContextAndGroupId } from '../../../../../lib/context-utils'
 
 export async function GET(req: Request) {
   const session = await getServerSession(authOptions)
   if (!session) {
     return new Response('Unauthorized', { status: 401 })
   }
-  const cookie = req.headers.get('cookie') || ''
-  const match = cookie.match(/(?:^|; )context=([^;]+)/)
-  const requested = match ? decodeURIComponent(match[1]) : 'personal'
-  const ctx = getRequestContext(req)
+  const { context: ctx, groupId } = getContextAndGroupId(req)
   if (ctx === 'group') {
     const groups = session.user?.groups ?? []
-    if (!groups.includes(requested)) {
+    if (!groupId || !groups.includes(groupId)) {
       return Response.json({ error: 'Forbidden' }, { status: 403 })
     }
   }

--- a/lib/context-utils.ts
+++ b/lib/context-utils.ts
@@ -1,0 +1,15 @@
+import { AppContext, getRequestContext } from './context'
+
+export function getContextAndGroupId(req: Request): { context: AppContext; groupId?: string } {
+  const context = getRequestContext(req)
+  const url = new URL(req.url)
+  const param = url.searchParams.get('groupId')
+  const cookie = req.headers.get('cookie') || ''
+  const matchGroup = cookie.match(/(?:^|; )groupId=([^;]+)/)
+  const fromGroup = matchGroup ? decodeURIComponent(matchGroup[1]) : undefined
+  const matchCtx = cookie.match(/(?:^|; )context=([^;]+)/)
+  const ctxVal = matchCtx ? decodeURIComponent(matchCtx[1]) : undefined
+  const fromContext = ctxVal && ctxVal !== 'personal' && ctxVal !== 'group' ? ctxVal : undefined
+  const groupId = param ?? fromGroup ?? fromContext
+  return { context, groupId }
+}

--- a/tests/context-utils.test.ts
+++ b/tests/context-utils.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { getContextAndGroupId } from '../lib/context-utils'
+
+describe('getContextAndGroupId', () => {
+  it('returns personal context by default', () => {
+    const { context, groupId } = getContextAndGroupId(new Request('http://test'))
+    expect(context).toBe('personal')
+    expect(groupId).toBeUndefined()
+  })
+
+  it('extracts groupId from query parameter', () => {
+    const req = new Request('http://test?groupId=team-a', {
+      headers: { cookie: 'context=group' },
+    })
+    const { context, groupId } = getContextAndGroupId(req)
+    expect(context).toBe('group')
+    expect(groupId).toBe('team-a')
+  })
+
+  it('falls back to groupId cookie', () => {
+    const req = new Request('http://test', {
+      headers: { cookie: 'context=group; groupId=team-b' },
+    })
+    const { context, groupId } = getContextAndGroupId(req)
+    expect(context).toBe('group')
+    expect(groupId).toBe('team-b')
+  })
+
+  it('uses context cookie value when it stores groupId', () => {
+    const req = new Request('http://test', {
+      headers: { cookie: 'context=team-c' },
+    })
+    const { context, groupId } = getContextAndGroupId(req)
+    expect(context).toBe('group')
+    expect(groupId).toBe('team-c')
+  })
+})


### PR DESCRIPTION
## Summary
- add getContextAndGroupId helper to parse context & groupId from request
- refactor schedule and budget report routes to use helper
- test helper for query, cookie and context fallbacks

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e04a314f88326907e18eed6806640