### PR TITLE
feat: allow layer selection when creating calendar events

### DIFF
--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -51,6 +51,7 @@ export default function CalendarPage() {
   const [shared, setShared] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [selectedLayers, setSelectedLayers] = useState<string[]>([])
+  const [layer, setLayer] = useState('')
 
   const socket = useSocket()
   const { data: session } = useSession()
@@ -58,6 +59,9 @@ export default function CalendarPage() {
 
   useEffect(() => {
     setSelectedLayers(data.layers.map(l => l.id))
+    if (data.layers.length > 0) {
+      setLayer(prev => (prev && data.layers.some(l => l.id === prev) ? prev : data.layers[0].id))
+    }
   }, [data.layers])
 
   useEffect(() => {
@@ -93,7 +97,6 @@ export default function CalendarPage() {
   const handleCreate = async (e: React.FormEvent) => {
     e.preventDefault()
     setError(null)
-    const layer = selectedLayers[0]
     const id = crypto.randomUUID()
     const res = await fetch('/api/schedule', {
       method: 'POST',
@@ -160,6 +163,18 @@ export default function CalendarPage() {
           onChange={e => setEnd(e.target.value)}
           className="border mr-2"
         />
+        <select
+          name="layer"
+          value={layer}
+          onChange={e => setLayer(e.target.value)}
+          className="border mr-2"
+        >
+          {data.layers.map(l => (
+            <option key={l.id} value={l.id}>
+              {l.name}
+            </option>
+          ))}
+        </select>
         <label className="mr-2">
           <input
             name="shared"

--- a/tests/calendar-page.test.tsx
+++ b/tests/calendar-page.test.tsx
@@ -160,10 +160,16 @@ describe('CalendarPage', () => {
     expect(alert?.textContent).toBe('Forbidden');
   });
 
-  it('creates events with id and shared flag', async () => {
+  it('creates events with id, shared flag, and selected layer', async () => {
     const mutate = vi.fn();
     swrMock = vi.fn(() => ({
-      data: { events: [], layers: [{ id: 'a', name: 'A', color: '#f00' }] },
+      data: {
+        events: [],
+        layers: [
+          { id: 'a', name: 'A', color: '#f00' },
+          { id: 'b', name: 'B', color: '#0f0' },
+        ],
+      },
       mutate,
     }));
 
@@ -177,6 +183,7 @@ describe('CalendarPage', () => {
 
     const title = container.querySelector('input[name="title"]') as HTMLInputElement;
     const start = container.querySelector('input[name="start"]') as HTMLInputElement;
+    const layerSelect = container.querySelector('select[name="layer"]') as HTMLSelectElement;
     const shared = container.querySelector('input[name="shared"]') as HTMLInputElement;
     const form = title.closest('form') as HTMLFormElement;
 
@@ -185,6 +192,8 @@ describe('CalendarPage', () => {
       title.dispatchEvent(new Event('input', { bubbles: true }));
       start.value = '2023-01-01';
       start.dispatchEvent(new Event('input', { bubbles: true }));
+      layerSelect.value = 'b';
+      layerSelect.dispatchEvent(new Event('change', { bubbles: true }));
       shared.checked = true;
       shared.dispatchEvent(new Event('change', { bubbles: true }));
     });
@@ -197,6 +206,7 @@ describe('CalendarPage', () => {
     const body = JSON.parse(fetchMock.mock.calls[0][1].body);
     expect(body.id).toBe('uuid-1');
     expect(body.shared).toBe(true);
+    expect(body.layer).toBe('b');
     expect(body.owner).toBe('user1');
   });
 


### PR DESCRIPTION
## Summary
- add dropdown to choose event layer on calendar
- include chosen layer in event creation request
- test creating events with selected layer

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f365a08f48326b795fbec69190931