### PR TITLE
Refresh finance data when context changes

### DIFF
--- a/tests/finance-page.test.tsx
+++ b/tests/finance-page.test.tsx
@@ -126,5 +126,30 @@ describe('FinancePage', () => {
     const { container } = render(<FinancePage />);
     expect(container.textContent).toContain('Failed to load budget options.');
   });
+
+  it('loads new data when the context cookie changes', async () => {
+    vi.useFakeTimers();
+    document.cookie = 'context=personal';
+    const mutate = vi.fn();
+    swrMock = vi.fn((key: string) => {
+      const match = key.match(/context=([^&]+)/);
+      const ctx = match ? match[1] : 'personal';
+      return {
+        data:
+          ctx === 'team-a'
+            ? [{ category: 'Office Rent', amount: 2000, costOfDeviation: 1000 }]
+            : [{ category: 'Rent', amount: 1000, costOfDeviation: 0 }],
+        mutate,
+      };
+    });
+    const { container } = render(<FinancePage />);
+    expect(container.textContent).toContain('Rent');
+    document.cookie = 'context=team-a';
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(container.textContent).toContain('Office Rent');
+    vi.useRealTimers();
+  });
 });
 


### PR DESCRIPTION
## Summary
- include context cookie value in FinancePage SWR key and watch for changes
- trigger mutate when context cookie updates to fetch new data
- test context switching loads context-specific finance data

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f2dd7b678832696528a660aaaeda1