### PR TITLE
Use context change event for calendar refresh

### DIFF
--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -65,17 +65,15 @@ export default function CalendarPage() {
   }, [data.layers])
 
   useEffect(() => {
-    const interval = setInterval(() => {
+    const handleContextChange = () => {
       const current = getContext()
-      setContext(prev => {
-        if (prev !== current) {
-          mutate()
-          return current
-        }
-        return prev
-      })
-    }, 1000)
-    return () => clearInterval(interval)
+      setContext(current)
+      mutate()
+    }
+    window.addEventListener('context-changed', handleContextChange)
+    return () => {
+      window.removeEventListener('context-changed', handleContextChange)
+    }
   }, [mutate])
 
   const handleNL = (e: React.FormEvent) => {

--- a/app/components/ContextSwitcher.tsx
+++ b/app/components/ContextSwitcher.tsx
@@ -39,6 +39,7 @@ export default function ContextSwitcher() {
   const update = (value: ContextType) => {
     setContext(value)
     document.cookie = `context=${value}; path=/`
+    window.dispatchEvent(new Event('context-changed'))
   }
 
   if (!session) return null


### PR DESCRIPTION
## Summary
- dispatch `context-changed` event when switching context
- listen for `context-changed` in calendar page instead of polling

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f3aab4d68832698b8a3483fd470c4