### PR TITLE
test: timezone and layer selection coverage

### DIFF
--- a/tests/calendar-page.test.tsx
+++ b/tests/calendar-page.test.tsx
@@ -87,6 +87,32 @@ describe('CalendarPage', () => {
     ]);
   });
 
+  it('updates layer field when selecting from dropdown', () => {
+    const mutate = vi.fn();
+    swrMock = vi.fn(() => ({
+      data: {
+        events: [],
+        layers: [
+          { id: 'a', name: 'A', color: '#f00' },
+          { id: 'b', name: 'B', color: '#0f0' },
+        ],
+      },
+      mutate,
+    }));
+
+    const { container } = render(<CalendarPage />);
+
+    const layerSelect = container.querySelector('select[name="layer"]') as HTMLSelectElement;
+    expect(layerSelect.value).toBe('a');
+
+    act(() => {
+      layerSelect.value = 'b';
+      layerSelect.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+
+    expect(layerSelect.value).toBe('b');
+  });
+
   it('sends NL command with personal context', async () => {
     const mutate = vi.fn();
     swrMock = vi.fn(() => ({ data: { events: [], layers: [] }, mutate }));
@@ -197,6 +223,8 @@ describe('CalendarPage', () => {
       shared.checked = true;
       shared.dispatchEvent(new Event('change', { bubbles: true }));
     });
+
+    expect(layerSelect.value).toBe('b');
 
     await act(async () => {
       form.dispatchEvent(new Event('submit', { bubbles: true }));

--- a/tests/schedule-timezone.test.tsx
+++ b/tests/schedule-timezone.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { act } from 'react-dom/test-utils'
+import ScheduleCalendar from '../app/components/ScheduleCalendar'
+
+vi.mock('../app/socket-context', () => ({
+  __esModule: true,
+  useCalendarEvents: () => null,
+  useTaskStatus: () => null,
+}))
+
+const dayCells: Record<string, React.ReactElement> = {}
+vi.mock('@fullcalendar/react', () => ({
+  __esModule: true,
+  default: (props: any) => {
+    dayCells['2024-05-20'] = props.dayCellContent({ date: new Date(2024, 4, 20), dayNumberText: '20' })
+    dayCells['2024-05-21'] = props.dayCellContent({ date: new Date(2024, 4, 21), dayNumberText: '21' })
+    return React.createElement('div')
+  },
+}))
+
+function render(ui: React.ReactElement) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = ReactDOM.createRoot(container)
+  act(() => {
+    root.render(ui)
+  })
+  return { container, root }
+}
+
+describe('ScheduleCalendar timezone handling', () => {
+  beforeEach(() => {
+    process.env.TZ = 'America/Los_Angeles'
+    document.body.innerHTML = ''
+    for (const key of Object.keys(dayCells)) delete dayCells[key]
+  })
+
+  it('renders event near midnight on correct local day', () => {
+    const events = [{ id: 'e1', title: 'Late', start: '2024-05-21T06:30:00Z' }]
+    render(<ScheduleCalendar events={events} layers={[]} visibleLayers={[]} mutate={() => {}} />)
+    const cell20 = dayCells['2024-05-20']
+    const cell21 = dayCells['2024-05-21']
+    expect(cell20).toBeTruthy()
+    expect(cell21).toBeTruthy()
+    const { container: c20 } = render(cell20 as React.ReactElement)
+    const { container: c21 } = render(cell21 as React.ReactElement)
+    expect(c20.firstChild?.getAttribute('title')).toBe('1 events')
+    expect(c21.firstChild?.getAttribute('title')).toBe('0 events')
+  })
+})

--- a/tests/socket-events.test.tsx
+++ b/tests/socket-events.test.tsx
@@ -100,6 +100,7 @@ describe('socket event propagation', () => {
       </SocketProvider>
     );
     await act(async () => {});
+    mutate.mockReset();
     await act(async () => {
       onmessage?.({ data: JSON.stringify({ type: 'finance.decision.result' }) });
     });


### PR DESCRIPTION
## Summary
- add schedule timezone test ensuring near-midnight events render on correct day
- verify calendar layer dropdown updates state and submits chosen layer
- fix finance websocket test by clearing initial mutate call

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f3ebc178c8326850cc769d3dda0da