### PR TITLE
Handle drop request failures

### DIFF
--- a/app/finance/page.tsx
+++ b/app/finance/page.tsx
@@ -1,5 +1,5 @@
 'use client'
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import useSWR from 'swr'
 import { fetcher } from '../../lib/swr'
 import { BudgetOption, rankBudgetOptions } from '../../lib/finance'
@@ -32,7 +32,12 @@ export default function FinancePage() {
     }, 1000)
     return () => clearInterval(interval)
   }, [context])
+  const initialRender = useRef(true)
   useEffect(() => {
+    if (initialRender.current) {
+      initialRender.current = false
+      return
+    }
     mutate()
   }, [context, mutate])
   useEffect(() => {


### PR DESCRIPTION
## Summary
- handle calendar drop errors by reverting changes and storing message
- expose drop errors to users via accessible alert
- defer initial finance data revalidation to avoid extraneous mutate call

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f3ebb8d9c8326bfcefd5df56d62ac