### PR TITLE
Use context-changed event in FinancePage

### DIFF
--- a/app/finance/page.tsx
+++ b/app/finance/page.tsx
@@ -23,15 +23,16 @@ export default function FinancePage() {
   const [paymentSchedules, setPaymentSchedules] = useState<Record<string, any[]>>({})
   const [aiExplanations, setAiExplanations] = useState<Record<string, string>>({})
   useEffect(() => {
-    const interval = setInterval(() => {
+    const handleContextChange = () => {
       const match = document.cookie.match(/(?:^|; )context=([^;]+)/)
       const ctx = match ? match[1] : 'personal'
-      if (ctx !== context) {
-        setContext(ctx)
-      }
-    }, 1000)
-    return () => clearInterval(interval)
-  }, [context])
+      setContext(ctx)
+    }
+    window.addEventListener('context-changed', handleContextChange)
+    return () => {
+      window.removeEventListener('context-changed', handleContextChange)
+    }
+  }, [])
   const initialRender = useRef(true)
   useEffect(() => {
     if (initialRender.current) {

--- a/tests/finance-page.test.tsx
+++ b/tests/finance-page.test.tsx
@@ -127,8 +127,7 @@ describe('FinancePage', () => {
     expect(container.textContent).toContain('Failed to load budget options.');
   });
 
-  it('loads new data when the context cookie changes', async () => {
-    vi.useFakeTimers();
+  it('loads new data when the context cookie changes', () => {
     document.cookie = 'context=personal';
     const mutate = vi.fn();
     swrMock = vi.fn((key: string) => {
@@ -145,11 +144,10 @@ describe('FinancePage', () => {
     const { container } = render(<FinancePage />);
     expect(container.textContent).toContain('Rent');
     document.cookie = 'context=team-a';
-    await act(async () => {
-      vi.advanceTimersByTime(1000);
+    act(() => {
+      window.dispatchEvent(new Event('context-changed'));
     });
     expect(container.textContent).toContain('Office Rent');
-    vi.useRealTimers();
   });
 });
 


### PR DESCRIPTION
## Summary
- handle context updates in FinancePage via `context-changed` event instead of polling
- remove timer-based test logic in favour of dispatching the context change event

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f44b343cc83269d25f8c01d04e91e