### PR TITLE
Use context helper for task routes

### DIFF
--- a/tests/schedule-group-permissions.test.ts
+++ b/tests/schedule-group-permissions.test.ts
@@ -138,7 +138,7 @@ describe('schedule group permissions', () => {
       body: JSON.stringify({ start: '2024-05-01' }),
       headers: {
         'Content-Type': 'application/json',
-        cookie: 'context=team-a',
+        cookie: 'context=group; groupId=team-a',
       },
     })
     const badRes = await PATCH(badReq, { params: { id: '3' } })
@@ -152,7 +152,7 @@ describe('schedule group permissions', () => {
       body: JSON.stringify({ start: '2024-05-01' }),
       headers: {
         'Content-Type': 'application/json',
-        cookie: 'context=team-a',
+        cookie: 'context=group; groupId=team-a',
       },
     })
     const okRes = await PATCH(okReq, { params: { id: '3' } })


### PR DESCRIPTION
## Summary
- use getContextAndGroupId in task routes to standardize context handling
- enforce groupId presence and membership in task GET/PATCH
- adjust schedule group permission tests for new cookie format

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f44b376d08326a8fa5fc2a6d4b90b