### PR TITLE
feat(calendar): add user legend for event owners

### DIFF
--- a/app/components/UserLegend.tsx
+++ b/app/components/UserLegend.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import React from 'react'
+
+interface UserLegendProps {
+  userColors: Record<string, string>
+}
+
+export default function UserLegend({ userColors }: UserLegendProps) {
+  const entries = Object.entries(userColors)
+  if (entries.length === 0) return null
+  return (
+    <div className="flex items-center gap-2 mt-2 text-xs" aria-label="User color legend">
+      {entries.map(([user, color]) => (
+        <div key={user} className="flex items-center gap-1">
+          <span className="w-3 h-3 rounded-sm" style={{ backgroundColor: color }} />
+          <span>{user.slice(0, 2).toUpperCase()}</span>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/tests/schedule-legend.test.tsx
+++ b/tests/schedule-legend.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { act } from 'react-dom/test-utils'
+import ScheduleCalendar from '../app/components/ScheduleCalendar'
+
+vi.mock('../app/socket-context', () => ({
+  __esModule: true,
+  useCalendarEvents: () => null,
+  useTaskStatus: () => null,
+}))
+
+vi.mock('@fullcalendar/react', () => ({
+  __esModule: true,
+  default: () => React.createElement('div')
+}))
+
+function render(ui: React.ReactElement) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = ReactDOM.createRoot(container)
+  act(() => {
+    root.render(ui)
+  })
+  return { container, root }
+}
+
+describe('ScheduleCalendar user legend', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('displays legend entries for event owners', () => {
+    const events = [
+      { id: '1', title: 'A', start: '2024-05-20T10:00:00', owner: 'alice' },
+      { id: '2', title: 'B', start: '2024-05-21T10:00:00', owner: 'bob' },
+    ]
+    render(<ScheduleCalendar events={events} layers={[]} visibleLayers={[]} mutate={() => {}} />)
+    const legend = document.querySelector('[aria-label="User color legend"]') as HTMLElement
+    expect(legend).toBeTruthy()
+    expect(legend.textContent).toContain('AL')
+    expect(legend.textContent).toContain('BO')
+  })
+})


### PR DESCRIPTION
## Summary
- color events by owner using deterministic palette
- render per-user color legend via new `UserLegend` component
- test calendar legend rendering

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f48f368a08326adab9132c5c49e0b