### PR TITLE
Add label to context switcher select

### DIFF
--- a/app/components/ContextSwitcher.tsx
+++ b/app/components/ContextSwitcher.tsx
@@ -45,13 +45,20 @@ export default function ContextSwitcher() {
   if (!session) return null
 
   return (
-    <select value={context} onChange={e => update(e.target.value)}>
-      <option value="personal">Personal</option>
-      {groups.map(g => (
-        <option key={g} value={g}>
-          {g}
-        </option>
-      ))}
-    </select>
+    <label htmlFor="context-select">
+      Context
+      <select
+        id="context-select"
+        value={context}
+        onChange={e => update(e.target.value)}
+      >
+        <option value="personal">Personal</option>
+        {groups.map(g => (
+          <option key={g} value={g}>
+            {g}
+          </option>
+        ))}
+      </select>
+    </label>
   )
 }

--- a/tests/context-switcher.test.tsx
+++ b/tests/context-switcher.test.tsx
@@ -54,6 +54,16 @@ describe('ContextSwitcher', () => {
     expect(fetchMock).toHaveBeenCalledWith('/api/groups')
   })
 
+  it('renders an associated label', async () => {
+    render(<ContextSwitcher />)
+    await act(async () => {})
+    const label = document.querySelector('label')
+    const select = document.querySelector('select') as HTMLSelectElement
+    expect(label).toBeTruthy()
+    expect(label?.getAttribute('for')).toBe(select.id)
+    expect(label?.textContent).toContain('Context')
+  })
+
   it('updates cookie on selection change', async () => {
     document.cookie = 'context=team-a'
     render(<ContextSwitcher />)


### PR DESCRIPTION
## Summary
- Add accessible label for context switcher select
- Test presence and association of the label

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f4924888483269c29de953351365d