### PR TITLE
Add login page with NextAuth options and nav link

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,10 +1,10 @@
 import "./globals.css";
 import { SocketProvider } from "./socket-context";
-import { ReactNode, useEffect } from 'react';
+import { ReactNode } from 'react';
 
 import { SWRProvider } from '../lib/swr';
 import Link from 'next/link';
-import { SessionProvider, signIn, signOut, useSession } from 'next-auth/react';
+import { SessionProvider, signOut, useSession } from 'next-auth/react';
 import { ThemeProvider, useTheme } from './theme-context';
 import ContextSwitcher from './components/ContextSwitcher';
 
@@ -41,7 +41,7 @@ function Shell({ children }: { children: ReactNode }) {
   );
 }
 
-function ShellContent({
+export function ShellContent({
   children,
   toggleTheme,
 }: {
@@ -58,7 +58,7 @@ function ShellContent({
           {session ? (
             <button type="button" onClick={() => signOut()}>Sign out</button>
           ) : (
-            <button type="button" onClick={() => signIn()}>Sign in</button>
+            <Link href="/login">Sign in</Link>
           )}
           <ContextSwitcher />
           <button type="button" onClick={toggleTheme}>Toggle Theme</button>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { signIn, useSession } from 'next-auth/react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useEffect } from 'react';
+
+export default function LoginPage() {
+  const { data: session } = useSession();
+  const router = useRouter();
+  const params = useSearchParams();
+  const callbackUrl = params.get('callbackUrl') ?? '/';
+
+  useEffect(() => {
+    if (session) {
+      router.replace(callbackUrl);
+    }
+  }, [session, router, callbackUrl]);
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const form = e.currentTarget;
+    const username = (form.elements.namedItem('username') as HTMLInputElement).value;
+    const password = (form.elements.namedItem('password') as HTMLInputElement).value;
+    await signIn('credentials', {
+      username,
+      password,
+      redirect: true,
+      callbackUrl,
+    });
+  }
+
+  return (
+    <div>
+      <h1>Login</h1>
+      <button type="button" onClick={() => signIn('github', { callbackUrl })}>
+        Sign in with GitHub
+      </button>
+      <form onSubmit={handleSubmit}>
+        <label>
+          Username
+          <input name="username" type="text" />
+        </label>
+        <label>
+          Password
+          <input name="password" type="password" />
+        </label>
+        <button type="submit">Sign in</button>
+      </form>
+    </div>
+  );
+}
+

--- a/tests/login-page.test.tsx
+++ b/tests/login-page.test.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { act } from 'react';
+
+import LoginPage from '../app/login/page';
+import { ShellContent } from '../app/layout';
+
+let sessionMock: any;
+
+(globalThis as any).React = React;
+
+vi.mock('next-auth/react', () => {
+  const React = require('react');
+  return {
+    SessionProvider: ({ children }: any) => React.createElement('div', null, children),
+    useSession: () => sessionMock,
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+  };
+});
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: vi.fn() }),
+  useSearchParams: () => ({ get: () => null }),
+}));
+
+vi.mock('../lib/swr', () => {
+  const React = require('react');
+  return {
+    SWRProvider: ({ children }: any) => React.createElement('div', null, children),
+  };
+});
+
+vi.mock('../app/socket-context', () => {
+  const React = require('react');
+  return {
+    SocketProvider: ({ children }: any) => React.createElement('div', null, children),
+    useSocket: () => null,
+    useTaskStatus: () => null,
+  };
+});
+
+vi.mock('../app/theme-context', () => {
+  const React = require('react');
+  return {
+    ThemeProvider: ({ children }: any) => React.createElement('div', null, children),
+    useTheme: () => ({ theme: 'cyber', setTheme: vi.fn() }),
+  };
+});
+
+vi.mock('../app/components/ContextSwitcher', () => {
+  const React = require('react');
+  return {
+    __esModule: true,
+    default: () => React.createElement('div'),
+  };
+});
+
+function render(ui: React.ReactElement) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = ReactDOM.createRoot(container);
+  act(() => {
+    root.render(ui);
+  });
+  return { container, root };
+}
+
+describe('Login flow', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    sessionMock = { data: null };
+  });
+
+  it('renders login page', async () => {
+    render(<LoginPage />);
+    await act(async () => {});
+    const btn = document.querySelector('button');
+    expect(btn?.textContent).toContain('GitHub');
+  });
+
+  it('shows login link in navigation', () => {
+    const html = renderToStaticMarkup(
+      <ShellContent toggleTheme={() => {}}>{null}</ShellContent>
+    );
+    expect(html).toContain('href="/login"');
+  });
+});
+


### PR DESCRIPTION
## Summary
- add custom `/login` page offering GitHub and credentials sign-in
- link unauthenticated users to `/login` from navigation
- test login page rendering and navigation link

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f49240aa88326bd17807cf4e755e1