### PR TITLE
Add group support to NextAuth session

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -28,12 +28,24 @@ export const authOptions: NextAuthOptions = {
     strategy: 'jwt',
   },
   callbacks: {
+    async jwt({ token, user }) {
+      if (user) {
+        token.groups = ['team-a', 'team-b']
+      }
+      if (!token.groups) {
+        token.groups = []
+      }
+      return token
+    },
     async session({ session, token }) {
       if (session.user && token.sub) {
         session.user.id = token.sub as string
       }
       if (token.accessToken) {
         ;(session as any).accessToken = token.accessToken as string
+      }
+      if ((token as any).groups) {
+        ;(session as any).groups = (token as any).groups as string[]
       }
       return session
     },

--- a/app/api/groups/route.ts
+++ b/app/api/groups/route.ts
@@ -6,6 +6,6 @@ export async function GET() {
   if (!session) {
     return new Response('Unauthorized', { status: 401 })
   }
-  const groups = session.user?.groups ?? []
+  const groups = session.groups ?? []
   return Response.json({ groups })
 }

--- a/app/api/schedule/route.ts
+++ b/app/api/schedule/route.ts
@@ -14,7 +14,7 @@ export async function GET(req: Request) {
     if (!groupId) {
       return new Response('groupId required', { status: 400 })
     }
-    const groups = session.user?.groups ?? []
+    const groups = session.groups ?? []
     if (!groups.includes(groupId)) {
       return new Response('Forbidden', { status: 403 })
     }
@@ -36,7 +36,7 @@ export async function POST(req: Request) {
     if (!groupId) {
       return Response.json({ error: 'groupId required' }, { status: 400 })
     }
-    const groups = session.user?.groups ?? []
+    const groups = session.groups ?? []
     if (!groups.includes(groupId)) {
       return new Response('Forbidden', { status: 403 })
     }

--- a/app/api/task/[id]/route.ts
+++ b/app/api/task/[id]/route.ts
@@ -22,7 +22,7 @@ export async function GET(
     if (!requested) {
       return new Response('groupId required', { status: 400 })
     }
-    const groups = session.user?.groups ?? []
+    const groups = session.groups ?? []
     if (!event.shared || !groupId || groupId !== requested || !groups.includes(groupId)) {
       return new Response('Forbidden', { status: 403 })
     }
@@ -50,7 +50,7 @@ export async function PATCH(
     if (!requested) {
       return new Response('groupId required', { status: 400 })
     }
-    const groups = session.user?.groups ?? []
+    const groups = session.groups ?? []
     if (!existing.shared || !groupId || groupId !== requested || !groups.includes(groupId)) {
       return new Response('Forbidden', { status: 403 })
     }

--- a/app/api/v1/report/budget/history/[id]/route.ts
+++ b/app/api/v1/report/budget/history/[id]/route.ts
@@ -37,7 +37,7 @@ export async function GET(
   }
   const { context: ctx, groupId } = getContextAndGroupId(req)
   if (ctx === 'group') {
-    const groups = session.user?.groups ?? []
+    const groups = session.groups ?? []
     if (!groupId || !groups.includes(groupId)) {
       return Response.json({ error: 'Forbidden' }, { status: 403 })
     }

--- a/app/api/v1/report/budget/history/route.ts
+++ b/app/api/v1/report/budget/history/route.ts
@@ -10,7 +10,7 @@ export async function GET(req: Request) {
   }
   const { context: ctx, groupId } = getContextAndGroupId(req)
   if (ctx === 'group') {
-    const groups = session.user?.groups ?? []
+    const groups = session.groups ?? []
     if (!groupId || !groups.includes(groupId)) {
       return Response.json({ error: 'Forbidden' }, { status: 403 })
     }

--- a/app/api/v1/report/budget/route.ts
+++ b/app/api/v1/report/budget/route.ts
@@ -10,7 +10,7 @@ export async function GET(req: Request) {
   }
   const { context: ctx, groupId } = getContextAndGroupId(req)
   if (ctx === 'group') {
-    const groups = session.user?.groups ?? []
+    const groups = session.groups ?? []
     if (!groupId || !groups.includes(groupId)) {
       return Response.json({ error: 'Forbidden' }, { status: 403 })
     }

--- a/app/components/ContextSwitcher.tsx
+++ b/app/components/ContextSwitcher.tsx
@@ -19,8 +19,8 @@ export default function ContextSwitcher() {
 
   useEffect(() => {
     async function loadGroups() {
-      if (session?.user?.groups && session.user.groups.length) {
-        setGroups(session.user.groups)
+      if (session?.groups && session.groups.length) {
+        setGroups(session.groups)
         return
       }
       try {

--- a/tests/api-routes.test.ts
+++ b/tests/api-routes.test.ts
@@ -123,7 +123,8 @@ describe('schedule API routes', () => {
     )
 
     vi.mocked(getServerSession).mockResolvedValue({
-      user: { id: '1', groups: ['team-a'] },
+      user: { id: '1' },
+      groups: ['team-a'],
     })
     const {
       schedule: { GET, POST },
@@ -188,7 +189,8 @@ describe('schedule API routes', () => {
     }
 
     vi.mocked(getServerSession).mockResolvedValue({
-      user: { id: '1', groups: ['team-a'] },
+      user: { id: '1' },
+      groups: ['team-a'],
     })
     const postReq = new Request('http://test', {
       method: 'POST',
@@ -198,7 +200,8 @@ describe('schedule API routes', () => {
     await POST(postReq)
 
     vi.mocked(getServerSession).mockResolvedValue({
-      user: { id: '1', groups: ['team-a'] },
+      user: { id: '1' },
+      groups: ['team-a'],
     })
     const getRes = await GET(
       new Request('http://test', { headers: { cookie: 'context=team-a' } }),
@@ -209,7 +212,8 @@ describe('schedule API routes', () => {
     expect(data.groupId).toBe('team-a')
 
     vi.mocked(getServerSession).mockResolvedValue({
-      user: { id: '1', groups: ['team-a'] },
+      user: { id: '1' },
+      groups: ['team-a'],
     })
     const badGet = await GET(
       new Request('http://test', { headers: { cookie: 'context=team-b' } }),
@@ -218,7 +222,8 @@ describe('schedule API routes', () => {
     expect(badGet.status).toBe(403)
 
     vi.mocked(getServerSession).mockResolvedValue({
-      user: { id: '2', groups: ['team-b'] },
+      user: { id: '2' },
+      groups: ['team-b'],
     })
     const patchReq = new Request('http://test', {
       method: 'PATCH',
@@ -233,7 +238,8 @@ describe('schedule API routes', () => {
 describe('budget report API route', () => {
   it('returns personal and group budget data based on context', async () => {
     vi.mocked(getServerSession).mockResolvedValue({
-      user: { id: '1', groups: ['team-a'] },
+      user: { id: '1' },
+      groups: ['team-a'],
     })
     const { GET } = await import('../app/api/v1/report/budget/route')
     const resPersonal = await GET(

--- a/tests/context-switcher.test.tsx
+++ b/tests/context-switcher.test.tsx
@@ -25,15 +25,18 @@ describe('ContextSwitcher', () => {
     document.cookie = 'context=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/'
     vi.unstubAllGlobals()
     vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true)
-    sessionMock = { data: { user: { id: '1', groups: ['team-a', 'team-b'] } } }
+    sessionMock = { data: { user: { id: '1' }, groups: ['team-a', 'team-b'] } }
   })
 
   it('uses initial context from cookie', async () => {
     document.cookie = 'context=team-b'
+    const fetchMock = vi.fn()
+    global.fetch = fetchMock as any
     render(<ContextSwitcher />)
     await act(async () => {})
     const select = document.querySelector('select') as HTMLSelectElement
     expect(select.value).toBe('team-b')
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 
   it('populates group options from API', async () => {

--- a/tests/finance-auth.api.test.ts
+++ b/tests/finance-auth.api.test.ts
@@ -32,7 +32,10 @@ describe('finance report auth', () => {
   })
 
   it.each(routes)('returns 403 for unauthorized group access on %s', async (path, params) => {
-    vi.mocked(getServerSession).mockResolvedValue({ user: { id: '1', groups: [] } })
+    vi.mocked(getServerSession).mockResolvedValue({
+      user: { id: '1' },
+      groups: [],
+    })
     const mod: any = await import(path)
     const res = await mod.GET(
       new Request('http://test', { headers: { cookie: 'context=team-a' } }),

--- a/tests/groups.api.test.ts
+++ b/tests/groups.api.test.ts
@@ -11,7 +11,10 @@ vi.mock('next-auth', async () => {
 
 describe('groups API route', () => {
   it('returns groups from session', async () => {
-    vi.mocked(getServerSession).mockResolvedValue({ user: { id: '1', groups: ['Team A'] } })
+    vi.mocked(getServerSession).mockResolvedValue({
+      user: { id: '1' },
+      groups: ['Team A'],
+    })
     const { GET } = await import('../app/api/groups/route')
     const res = await GET()
     const data = await res.json()

--- a/tests/history-detail.api.test.ts
+++ b/tests/history-detail.api.test.ts
@@ -12,7 +12,8 @@ vi.mock('next-auth', async () => {
 describe('budget history detail API route', () => {
   it('returns actions scoped to context', async () => {
     vi.mocked(getServerSession).mockResolvedValue({
-      user: { id: '1', groups: ['team-a'] },
+      user: { id: '1' },
+      groups: ['team-a'],
     })
     const { GET } = await import('../app/api/v1/report/budget/history/[id]/route')
 

--- a/tests/history.api.test.ts
+++ b/tests/history.api.test.ts
@@ -12,7 +12,8 @@ vi.mock('next-auth', async () => {
 describe('budget history API route', () => {
   it('returns history scoped to context', async () => {
     vi.mocked(getServerSession).mockResolvedValue({
-      user: { id: '1', groups: ['team-a'] },
+      user: { id: '1' },
+      groups: ['team-a'],
     })
     const { GET } = await import('../app/api/v1/report/budget/history/route')
     const resPersonal = await GET(

--- a/tests/schedule-group-permissions.test.ts
+++ b/tests/schedule-group-permissions.test.ts
@@ -43,7 +43,8 @@ describe('schedule group permissions', () => {
     } = await loadModules()
 
     vi.mocked(getServerSession).mockResolvedValue({
-      user: { id: '1', groups: ['team-a'] },
+      user: { id: '1' },
+      groups: ['team-a'],
     })
     const badRes = await GET(
       new Request('http://test', {
@@ -71,7 +72,8 @@ describe('schedule group permissions', () => {
     } = await loadModules()
 
     vi.mocked(getServerSession).mockResolvedValue({
-      user: { id: '1', groups: ['team-a'] },
+      user: { id: '1' },
+      groups: ['team-a'],
     })
     const badReq = new Request('http://test', {
       method: 'POST',
@@ -131,7 +133,8 @@ describe('schedule group permissions', () => {
     } = await loadModules()
 
     vi.mocked(getServerSession).mockResolvedValue({
-      user: { id: '1', groups: ['team-b'] },
+      user: { id: '1' },
+      groups: ['team-b'],
     })
     const badReq = new Request('http://test', {
       method: 'PATCH',
@@ -145,7 +148,8 @@ describe('schedule group permissions', () => {
     expect(badRes.status).toBe(403)
 
     vi.mocked(getServerSession).mockResolvedValue({
-      user: { id: '1', groups: ['team-a'] },
+      user: { id: '1' },
+      groups: ['team-a'],
     })
     const okReq = new Request('http://test', {
       method: 'PATCH',

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -1,11 +1,17 @@
-import NextAuth, { DefaultSession } from 'next-auth'
+import { DefaultSession } from 'next-auth'
 
 // Extend the default session type to include the user id
 declare module 'next-auth' {
   interface Session {
     user?: {
       id: string
-      groups?: string[]
     } & DefaultSession['user']
+    groups?: string[]
+  }
+}
+
+declare module 'next-auth/jwt' {
+  interface JWT {
+    groups?: string[]
   }
 }


### PR DESCRIPTION
## Summary
- include mock `groups` array in JWT and session callbacks
- expose groups via API and consume from session in ContextSwitcher
- expand NextAuth types for groups support

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f54cc3f44832683b7ba7c9353abec