### PR TITLE
feat: add screen reader color labels to calendar layers

### DIFF
--- a/app/components/CalendarLayerPanel.tsx
+++ b/app/components/CalendarLayerPanel.tsx
@@ -24,7 +24,12 @@ export default function CalendarLayerPanel({ layers, selected, onToggle }: Calen
             checked={selected.includes(layer.id)}
             onChange={() => onToggle(layer.id)}
           />
-          <span className="w-3 h-3 inline-block" style={{ backgroundColor: layer.color }} />
+          <span
+            className="w-3 h-3 inline-block"
+            style={{ backgroundColor: layer.color }}
+            aria-hidden="true"
+          />
+          <span className="sr-only">Color: {layer.color}</span>
           <span>{layer.name}</span>
         </label>
       ))}

--- a/tests/schedule-accessibility.test.tsx
+++ b/tests/schedule-accessibility.test.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client'
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { act } from 'react-dom/test-utils'
 import ScheduleCalendar from '../app/components/ScheduleCalendar'
+import CalendarLayerPanel from '../app/components/CalendarLayerPanel'
 
 vi.mock('../app/socket-context', () => ({
   __esModule: true,
@@ -54,6 +55,19 @@ describe('ScheduleCalendar accessibility', () => {
     expect(tooltip).toBeTruthy()
     expect(tooltip.textContent).toContain('Invitees: Alice, Bob')
     expect(tooltip.textContent).toContain('Permissions: view, edit')
+  })
+
+  it('announces layer color', () => {
+    render(
+      <CalendarLayerPanel
+        layers={[{ id: '1', name: 'Test Layer', color: '#ff0000' }]}
+        selected={[]}
+        onToggle={() => {}}
+      />
+    )
+    const colorLabel = document.querySelector('.sr-only') as HTMLElement
+    expect(colorLabel).toBeTruthy()
+    expect(colorLabel.textContent).toBe('Color: #ff0000')
   })
 })
 


### PR DESCRIPTION
## Summary
- add hidden color labels to calendar layer items
- test that layer colors are announced for accessibility

## Testing
- `npm run lint`
- `npm test tests/schedule-accessibility.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a0af8313308326b46e7f99c5403bff