### PR TITLE
Show cost deviation for best finance option

### DIFF
--- a/app/finance/page.tsx
+++ b/app/finance/page.tsx
@@ -131,7 +131,7 @@ export default function FinancePage() {
                 )}
               </div>
               <p>Amount: ${option.amount}</p>
-              {!isBest && <p>Cost of deviation: ${option.costOfDeviation}</p>}
+              <p>Cost of deviation: ${isBest ? 0 : option.costOfDeviation}</p>
               <button
                 className="mt-2 text-blue-500 underline"
                 onClick={() => {

--- a/tests/finance-page.test.tsx
+++ b/tests/finance-page.test.tsx
@@ -51,7 +51,9 @@ describe('FinancePage', () => {
     expect(cards[1].className).not.toContain('border-green-500');
     expect(cards[0].textContent).toContain('Best');
     expect(cards[0].textContent).toContain('⭐');
-    expect(cards[0].textContent).not.toContain('Cost of deviation');
+    expect(cards[0].textContent).toContain('Cost of deviation: $0');
+    const costInfoBest = cards[0].querySelector('p:nth-of-type(2)') as HTMLParagraphElement;
+    expect(costInfoBest.textContent).toBe('Cost of deviation: $0');
     const costInfo = cards[1].querySelector('p:nth-of-type(2)') as HTMLParagraphElement;
     expect(costInfo.textContent).toMatch(/Cost of deviation:/);
     const viewBtn = cards[0].querySelector('button') as HTMLButtonElement;


### PR DESCRIPTION
## Summary
- Always display cost of deviation on finance cards, showing $0 for the best option while keeping the Best badge
- Update finance page test to expect the zero-cost deviation line

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0af8241e88326980b2f629f4efccb