### PR TITLE
Refactor context cookies

### DIFF
--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect } from 'react'
 import useSWR from 'swr'
 import { fetcher } from '../../lib/swr'
 import { AppContext } from '../../lib/context'
+import { getClientContext } from '../../lib/client-context'
 import ScheduleCalendar from '../components/ScheduleCalendar'
 import CalendarLayerPanel from '../components/CalendarLayerPanel'
 import { useSocket } from '../socket-context'
@@ -32,11 +33,7 @@ interface CalendarData {
   layers: Layer[]
 }
 
-const getContext = (): AppContext => {
-  const match = document.cookie.match(/(?:^|; )context=([^;]+)/)
-  const value = match ? decodeURIComponent(match[1]) : 'personal'
-  return value === 'personal' ? 'personal' : 'group'
-}
+const getContext = (): AppContext => getClientContext().context
 
 export default function CalendarPage() {
   const [context, setContext] = useState<AppContext>(getContext())
@@ -68,7 +65,7 @@ export default function CalendarPage() {
 
   useEffect(() => {
     const handleContextChange = () => {
-      const current = getContext()
+      const { context: current } = getClientContext()
       setContext(current)
       mutate()
     }
@@ -81,8 +78,7 @@ export default function CalendarPage() {
   const handleNL = (e: React.FormEvent) => {
     e.preventDefault()
     if (!nl) return
-    const match = document.cookie.match(/(?:^|; )context=([^;]+)/)
-    const context = match ? (match[1] === 'personal' ? 'personal' : 'group') : 'personal'
+    const { context } = getClientContext()
     socket?.send(
       JSON.stringify({
         type: 'calendar.nl.request',

--- a/app/components/ContextSwitcher.tsx
+++ b/app/components/ContextSwitcher.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useState } from 'react'
 import { useSession } from 'next-auth/react'
+import { getClientContext } from '../../lib/client-context'
 
 type ContextType = string
 
@@ -11,9 +12,9 @@ export default function ContextSwitcher() {
   const [groups, setGroups] = useState<string[]>([])
 
   useEffect(() => {
-    const match = document.cookie.match(/(?:^|; )context=([^;]+)/)
-    if (match) {
-      setContext(match[1])
+    const { context, groupId } = getClientContext()
+    if (context === 'group' && groupId) {
+      setContext(groupId)
     }
   }, [])
 
@@ -38,7 +39,13 @@ export default function ContextSwitcher() {
 
   const update = (value: ContextType) => {
     setContext(value)
-    document.cookie = `context=${value}; path=/`
+    if (value === 'personal') {
+      document.cookie = `context=personal; path=/`
+      document.cookie = `groupId=; Max-Age=0; path=/`
+    } else {
+      document.cookie = `context=group; path=/`
+      document.cookie = `groupId=${value}; path=/`
+    }
     window.dispatchEvent(new Event('context-changed'))
   }
 

--- a/lib/client-context.ts
+++ b/lib/client-context.ts
@@ -1,0 +1,14 @@
+import { AppContext } from './context'
+
+export function getClientContext(): { context: AppContext; groupId?: string } {
+  const cookies = document.cookie
+  const ctxMatch = cookies.match(/(?:^|; )context=([^;]+)/)
+  const ctxValue = ctxMatch ? decodeURIComponent(ctxMatch[1]) : 'personal'
+  const context: AppContext = ctxValue === 'group' ? 'group' : 'personal'
+  let groupId: string | undefined
+  if (context === 'group') {
+    const groupMatch = cookies.match(/(?:^|; )groupId=([^;]+)/)
+    groupId = groupMatch ? decodeURIComponent(groupMatch[1]) : undefined
+  }
+  return { context, groupId }
+}

--- a/lib/context-utils.ts
+++ b/lib/context-utils.ts
@@ -7,9 +7,6 @@ export function getContextAndGroupId(req: Request): { context: AppContext; group
   const cookie = req.headers.get('cookie') || ''
   const matchGroup = cookie.match(/(?:^|; )groupId=([^;]+)/)
   const fromGroup = matchGroup ? decodeURIComponent(matchGroup[1]) : undefined
-  const matchCtx = cookie.match(/(?:^|; )context=([^;]+)/)
-  const ctxVal = matchCtx ? decodeURIComponent(matchCtx[1]) : undefined
-  const fromContext = ctxVal && ctxVal !== 'personal' && ctxVal !== 'group' ? ctxVal : undefined
-  const groupId = param ?? fromGroup ?? fromContext
+  const groupId = param ?? fromGroup
   return { context, groupId }
 }

--- a/lib/context.ts
+++ b/lib/context.ts
@@ -4,5 +4,5 @@ export function getRequestContext(req: Request): AppContext {
   const cookie = req.headers.get('cookie') || ''
   const match = cookie.match(/(?:^|; )context=([^;]+)/)
   const value = match ? decodeURIComponent(match[1]) : 'personal'
-  return value === 'personal' ? 'personal' : 'group'
+  return value === 'group' ? 'group' : 'personal'
 }

--- a/tests/api-routes.test.ts
+++ b/tests/api-routes.test.ts
@@ -195,7 +195,7 @@ describe('schedule API routes', () => {
     const postReq = new Request('http://test', {
       method: 'POST',
       body: JSON.stringify(event),
-      headers: { 'Content-Type': 'application/json', cookie: 'context=team-a' },
+      headers: { 'Content-Type': 'application/json', cookie: 'context=group; groupId=team-a' },
     })
     await POST(postReq)
 
@@ -204,7 +204,7 @@ describe('schedule API routes', () => {
       groups: ['team-a'],
     })
     const getRes = await GET(
-      new Request('http://test', { headers: { cookie: 'context=team-a' } }),
+      new Request('http://test', { headers: { cookie: 'context=group; groupId=team-a' } }),
       { params: { id: event.id } },
     )
     expect(getRes.status).toBe(200)
@@ -216,7 +216,7 @@ describe('schedule API routes', () => {
       groups: ['team-a'],
     })
     const badGet = await GET(
-      new Request('http://test', { headers: { cookie: 'context=team-b' } }),
+      new Request('http://test', { headers: { cookie: 'context=group; groupId=team-b' } }),
       { params: { id: event.id } },
     )
     expect(badGet.status).toBe(403)
@@ -228,7 +228,7 @@ describe('schedule API routes', () => {
     const patchReq = new Request('http://test', {
       method: 'PATCH',
       body: JSON.stringify({ title: 'Updated' }),
-      headers: { 'Content-Type': 'application/json', cookie: 'context=team-a' },
+      headers: { 'Content-Type': 'application/json', cookie: 'context=group; groupId=team-a' },
     })
     const patchRes = await PATCH(patchReq, { params: { id: event.id } })
     expect(patchRes.status).toBe(403)
@@ -253,7 +253,7 @@ describe('budget report API route', () => {
     ])
 
     const resGroup = await GET(
-      new Request('http://test', { headers: { cookie: 'context=team-a' } }),
+      new Request('http://test', { headers: { cookie: 'context=group; groupId=team-a' } }),
     )
     const dataGroup = await resGroup.json()
     expect(dataGroup).toEqual([

--- a/tests/calendar-page.test.tsx
+++ b/tests/calendar-page.test.tsx
@@ -48,6 +48,7 @@ describe('CalendarPage', () => {
     vi.unstubAllGlobals();
     socketMock = { send: vi.fn() };
     document.cookie = 'context=personal';
+    document.cookie = 'groupId=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/';
   });
 
   it('configures multiple calendar views', () => {
@@ -137,7 +138,7 @@ describe('CalendarPage', () => {
   });
 
   it('sends NL command with group context', async () => {
-    document.cookie = 'context=team-a';
+    document.cookie = 'context=group; groupId=team-a';
     const mutate = vi.fn();
     swrMock = vi.fn(() => ({ data: { events: [], layers: [] }, mutate }));
 
@@ -367,7 +368,7 @@ describe('CalendarPage', () => {
       expect.objectContaining({ refreshInterval: 30000 }),
     );
 
-    document.cookie = 'context=team-a';
+    document.cookie = 'context=group; groupId=team-a';
     await act(async () => {
       vi.advanceTimersByTime(1000);
     });

--- a/tests/context-switcher.test.tsx
+++ b/tests/context-switcher.test.tsx
@@ -23,13 +23,14 @@ describe('ContextSwitcher', () => {
   beforeEach(() => {
     document.body.innerHTML = ''
     document.cookie = 'context=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/'
+    document.cookie = 'groupId=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/'
     vi.unstubAllGlobals()
     vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true)
     sessionMock = { data: { user: { id: '1' }, groups: ['team-a', 'team-b'] } }
   })
 
   it('uses initial context from cookie', async () => {
-    document.cookie = 'context=team-b'
+    document.cookie = 'context=group; groupId=team-b'
     const fetchMock = vi.fn()
     global.fetch = fetchMock as any
     render(<ContextSwitcher />)
@@ -68,7 +69,7 @@ describe('ContextSwitcher', () => {
   })
 
   it('updates cookie on selection change', async () => {
-    document.cookie = 'context=team-a'
+    document.cookie = 'context=group; groupId=team-a'
     render(<ContextSwitcher />)
     await act(async () => {})
     const select = document.querySelector('select') as HTMLSelectElement
@@ -76,7 +77,8 @@ describe('ContextSwitcher', () => {
       select.value = 'team-b'
       select.dispatchEvent(new Event('change', { bubbles: true }))
     })
-    expect(document.cookie).toContain('context=team-b')
+    expect(document.cookie).toContain('context=group')
+    expect(document.cookie).toContain('groupId=team-b')
     expect(select.value).toBe('team-b')
   })
 })

--- a/tests/context-utils.test.ts
+++ b/tests/context-utils.test.ts
@@ -26,12 +26,12 @@ describe('getContextAndGroupId', () => {
     expect(groupId).toBe('team-b')
   })
 
-  it('uses context cookie value when it stores groupId', () => {
+  it('returns undefined groupId when cookie missing', () => {
     const req = new Request('http://test', {
-      headers: { cookie: 'context=team-c' },
+      headers: { cookie: 'context=group' },
     })
     const { context, groupId } = getContextAndGroupId(req)
     expect(context).toBe('group')
-    expect(groupId).toBe('team-c')
+    expect(groupId).toBeUndefined()
   })
 })

--- a/tests/finance-auth.api.test.ts
+++ b/tests/finance-auth.api.test.ts
@@ -38,7 +38,7 @@ describe('finance report auth', () => {
     })
     const mod: any = await import(path)
     const res = await mod.GET(
-      new Request('http://test', { headers: { cookie: 'context=team-a' } }),
+      new Request('http://test', { headers: { cookie: 'context=group; groupId=team-a' } }),
       params,
     )
     expect(res.status).toBe(403)

--- a/tests/finance-page.test.tsx
+++ b/tests/finance-page.test.tsx
@@ -31,6 +31,7 @@ describe('FinancePage', () => {
     document.body.innerHTML = '';
     send = vi.fn();
     financeUpdate = null;
+    document.cookie = 'groupId=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/';
   });
 
   it('labels options, highlights best choice, and shows modal content', () => {
@@ -131,11 +132,13 @@ describe('FinancePage', () => {
     document.cookie = 'context=personal';
     const mutate = vi.fn();
     swrMock = vi.fn((key: string) => {
-      const match = key.match(/context=([^&]+)/);
-      const ctx = match ? match[1] : 'personal';
+      const matchCtx = key.match(/context=([^&]+)/);
+      const ctx = matchCtx ? matchCtx[1] : 'personal';
+      const matchGroup = key.match(/groupId=([^&]+)/);
+      const gid = matchGroup ? matchGroup[1] : undefined;
       return {
         data:
-          ctx === 'team-a'
+          ctx === 'group' && gid === 'team-a'
             ? [{ category: 'Office Rent', amount: 2000, costOfDeviation: 1000 }]
             : [{ category: 'Rent', amount: 1000, costOfDeviation: 0 }],
         mutate,
@@ -143,7 +146,7 @@ describe('FinancePage', () => {
     });
     const { container } = render(<FinancePage />);
     expect(container.textContent).toContain('Rent');
-    document.cookie = 'context=team-a';
+    document.cookie = 'context=group; groupId=team-a';
     act(() => {
       window.dispatchEvent(new Event('context-changed'));
     });

--- a/tests/history-detail.api.test.ts
+++ b/tests/history-detail.api.test.ts
@@ -27,7 +27,7 @@ describe('budget history detail API route', () => {
     ])
 
     const resGroup = await GET(
-      new Request('http://test', { headers: { cookie: 'context=team-a' } }),
+      new Request('http://test', { headers: { cookie: 'context=group; groupId=team-a' } }),
       { params: { id: 'g1' } },
     )
     const dataGroup = await resGroup.json()

--- a/tests/history.api.test.ts
+++ b/tests/history.api.test.ts
@@ -26,7 +26,7 @@ describe('budget history API route', () => {
     ])
 
     const resGroup = await GET(
-      new Request('http://test', { headers: { cookie: 'context=team-a' } }),
+      new Request('http://test', { headers: { cookie: 'context=group; groupId=team-a' } }),
     )
     const dataGroup = await resGroup.json()
     expect(dataGroup).toEqual([


### PR DESCRIPTION
## Summary
- add client helper to read context and groupId cookies
- set separate context and groupId cookies in context switcher
- update pages, server utilities, and tests to use new cookies

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0af8125e883268a91bcc3d1a871c1