### PR TITLE
Improve shared event tooltip accessibility

### DIFF
--- a/app/components/SharedEventTooltip.tsx
+++ b/app/components/SharedEventTooltip.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useState } from 'react'
+import React, { useId, useState } from 'react'
 
 interface SharedEventTooltipProps {
   children: React.ReactNode
@@ -10,6 +10,7 @@ interface SharedEventTooltipProps {
 
 export default function SharedEventTooltip({ children, invitees = [], permissions = [] }: SharedEventTooltipProps) {
   const [visible, setVisible] = useState(false)
+  const tooltipId = useId()
   const content = `Invitees: ${invitees.join(', ') || 'None'}\nPermissions: ${permissions.join(', ') || 'None'}`
   return (
     <div
@@ -19,10 +20,12 @@ export default function SharedEventTooltip({ children, invitees = [], permission
       onFocus={() => setVisible(true)}
       onBlur={() => setVisible(false)}
       tabIndex={0}
+      aria-describedby={visible ? tooltipId : undefined}
     >
       {children}
       {visible && (
         <div
+          id={tooltipId}
           role="tooltip"
           className="absolute z-10 p-2 text-xs text-white bg-gray-800 rounded shadow whitespace-pre-line"
         >

--- a/tests/shared-event-tooltip.test.tsx
+++ b/tests/shared-event-tooltip.test.tsx
@@ -33,7 +33,28 @@ describe('SharedEventTooltip', () => {
     expect(tooltip).toBeTruthy()
     expect(tooltip.textContent).toContain('Invitees: Alice, Bob')
     expect(tooltip.textContent).toContain('Permissions: view, edit')
-    expect(tooltip.getAttribute('role')).toBe('tooltip')
+    expect(trigger.getAttribute('aria-describedby')).toBe(tooltip.id)
+  })
+
+  it('toggles tooltip on focus and blur for keyboard users', () => {
+    render(
+      <SharedEventTooltip invitees={['Carol']} permissions={['view']}>
+        <span>Event</span>
+      </SharedEventTooltip>
+    )
+    const trigger = document.querySelector('div[tabindex="0"]') as HTMLElement
+    act(() => {
+      trigger.focus()
+    })
+    let tooltip = document.querySelector('[role="tooltip"]') as HTMLElement | null
+    expect(tooltip).toBeTruthy()
+    expect(trigger.getAttribute('aria-describedby')).toBe(tooltip!.id)
+    act(() => {
+      trigger.blur()
+    })
+    tooltip = document.querySelector('[role="tooltip"]')
+    expect(tooltip).toBeNull()
+    expect(trigger.hasAttribute('aria-describedby')).toBe(false)
   })
 })
 


### PR DESCRIPTION
## Summary
- link tooltip to trigger via `aria-describedby`
- support focus-based tooltip visibility
- test tooltip accessibility

## Testing
- `npm test tests/shared-event-tooltip.test.tsx`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0d430471c8326a02d2658b3a162c0