### PR TITLE
Add task deletion to schedule calendar

### DIFF
--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -7,7 +7,7 @@ import { AppContext } from '../../lib/context'
 import { getClientContext } from '../../lib/client-context'
 import ScheduleCalendar from '../components/ScheduleCalendar'
 import CalendarLayerPanel from '../components/CalendarLayerPanel'
-import { useSocket } from '../socket-context'
+import { useSocket, useCalendarEvents } from '../socket-context'
 import { useSession } from 'next-auth/react'
 
 interface Layer {
@@ -53,6 +53,7 @@ export default function CalendarPage() {
   const [layer, setLayer] = useState('')
 
   const socket = useSocket()
+  const calendarEvent = useCalendarEvents()
   const { data: session } = useSession()
   const [nl, setNl] = useState('')
 
@@ -62,6 +63,12 @@ export default function CalendarPage() {
       setLayer(prev => (prev && data.layers.some(l => l.id === prev) ? prev : data.layers[0].id))
     }
   }, [data.layers])
+
+  useEffect(() => {
+    if (calendarEvent?.type === 'calendar.event.deleted') {
+      mutate()
+    }
+  }, [calendarEvent, mutate])
 
   useEffect(() => {
     const handleContextChange = () => {

--- a/app/socket-context.tsx
+++ b/app/socket-context.tsx
@@ -94,6 +94,9 @@ export function SocketProvider({ children }: { children: React.ReactNode }) {
             case 'calendar.event.updated':
               setCalendarEvent(data);
               break;
+            case 'calendar.event.deleted':
+              setCalendarEvent(data);
+              break;
             case 'finance.decision.result':
             case 'finance.explain.result':
               setFinanceUpdate(data);

--- a/tests/schedule-delete.test.tsx
+++ b/tests/schedule-delete.test.tsx
@@ -1,0 +1,91 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { act } from 'react-dom/test-utils'
+import ScheduleCalendar from '../app/components/ScheduleCalendar'
+
+let calendarProps: any
+
+vi.mock('../app/socket-context', () => ({
+  __esModule: true,
+  useCalendarEvents: () => null,
+  useTaskStatus: () => null,
+  useSocketStatus: () => ({ connectionState: 'open', lastError: null, retry: () => {} }),
+}))
+
+vi.mock('@fullcalendar/react', () => ({
+  __esModule: true,
+  default: (props: any) => {
+    calendarProps = props
+    return React.createElement('div')
+  },
+}))
+
+function render(ui: React.ReactElement) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = ReactDOM.createRoot(container)
+  act(() => {
+    root.render(ui)
+  })
+  return { container, root }
+}
+
+describe('ScheduleCalendar delete', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    calendarProps = {}
+  })
+
+  const layers = [{ id: 'l1', name: 'Layer 1', color: '#f00' }]
+  const events = [{ id: 'e1', title: 'Event', start: '2024-05-20T10:00:00', layer: 'l1' }]
+
+  it('deletes events and refreshes list', async () => {
+    const mutate = vi.fn()
+    global.fetch = vi.fn(() => Promise.resolve(new Response(JSON.stringify({ success: true }), { status: 200 }))) as any
+    const { container } = render(<ScheduleCalendar events={events} layers={layers} visibleLayers={['l1']} mutate={mutate} />)
+
+    act(() => {
+      calendarProps.dateClick({ date: new Date('2024-05-20') })
+    })
+
+    const cell = calendarProps.dayCellContent({ date: new Date('2024-05-20'), dayNumberText: '20' })
+    const cellContainer = document.createElement('div')
+    const cellRoot = ReactDOM.createRoot(cellContainer)
+    act(() => {
+      cellRoot.render(cell)
+    })
+    const btn = cellContainer.querySelector('button') as HTMLButtonElement
+    expect(btn).toBeTruthy()
+    await act(async () => {
+      btn.click()
+    })
+    expect(global.fetch).toHaveBeenCalledWith('/api/task/e1', { method: 'DELETE' })
+    expect(mutate).toHaveBeenCalled()
+    expect(container.querySelector('[role="alert"]')).toBeNull()
+  })
+
+  it('shows error when delete fails', async () => {
+    const mutate = vi.fn()
+    global.fetch = vi.fn(() => Promise.resolve(new Response(JSON.stringify({ error: 'Nope' }), { status: 500 }))) as any
+    const { container } = render(<ScheduleCalendar events={events} layers={layers} visibleLayers={['l1']} mutate={mutate} />)
+
+    act(() => {
+      calendarProps.dateClick({ date: new Date('2024-05-20') })
+    })
+    const cell = calendarProps.dayCellContent({ date: new Date('2024-05-20'), dayNumberText: '20' })
+    const cellContainer = document.createElement('div')
+    const cellRoot = ReactDOM.createRoot(cellContainer)
+    act(() => {
+      cellRoot.render(cell)
+    })
+    const btn = cellContainer.querySelector('button') as HTMLButtonElement
+    await act(async () => {
+      btn.click()
+    })
+    const alert = container.querySelector('[role="alert"]') as HTMLElement
+    expect(alert.textContent).toBe('Nope')
+    expect(mutate).not.toHaveBeenCalled()
+  })
+})
+

--- a/tests/socket-events.test.tsx
+++ b/tests/socket-events.test.tsx
@@ -91,6 +91,21 @@ describe('socket event propagation', () => {
     expect(mutate).toHaveBeenCalled();
   });
 
+  it('refreshes calendar when an event is deleted', async () => {
+    const mutate = vi.fn();
+    swrMock = vi.fn();
+    render(
+      <SocketProvider>
+        <ScheduleCalendar events={[]} layers={[]} visibleLayers={[]} mutate={mutate} />
+      </SocketProvider>
+    );
+    await act(async () => {});
+    await act(async () => {
+      onmessage?.({ data: JSON.stringify({ type: 'calendar.event.deleted' }) });
+    });
+    expect(mutate).toHaveBeenCalled();
+  });
+
   it('refreshes finance data on updates', async () => {
     const mutate = vi.fn();
     swrMock = vi.fn(() => ({ data: [{ category: 'Rent', amount: 1000, costOfDeviation: 0 }], mutate }));


### PR DESCRIPTION
## Summary
- Add keyboard-accessible delete button for each calendar event and remove via `/api/task/{id}`
- Refresh schedule when `calendar.event.deleted` WebSocket messages arrive
- Cover event deletion with new tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0d42fca8c83269aeafcd7d77aea46