### PR TITLE
Ensure calendar delete control uses explicit button type

### DIFF
--- a/app/components/ScheduleCalendar.tsx
+++ b/app/components/ScheduleCalendar.tsx
@@ -216,6 +216,7 @@ export default function ScheduleCalendar({ events, layers, visibleLayers, mutate
                 {e.owner && <span className="mr-1">{e.owner.slice(0, 2).toUpperCase()}</span>}
                 {e.title || '(no title)'}
                 <button
+                  type="button"
                   className="ml-2 underline"
                   onClick={() => handleDelete(e.id)}
                   aria-label={`Delete ${e.title || 'event'}`}


### PR DESCRIPTION
## Summary
- Explicitly set `type="button"` on schedule event delete controls for clearer semantics

## Testing
- `npm test tests/schedule-delete.test.tsx`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a32e96b24c8326b04d4549bccfd48b