### PR TITLE
feat: improve shared event tooltip accessibility

### DIFF
--- a/app/components/SharedEventTooltip.tsx
+++ b/app/components/SharedEventTooltip.tsx
@@ -20,18 +20,19 @@ export default function SharedEventTooltip({ children, invitees = [], permission
       onFocus={() => setVisible(true)}
       onBlur={() => setVisible(false)}
       tabIndex={0}
-      aria-describedby={visible ? tooltipId : undefined}
+      aria-describedby={tooltipId}
     >
       {children}
-      {visible && (
-        <div
-          id={tooltipId}
-          role="tooltip"
-          className="absolute z-10 p-2 text-xs text-white bg-gray-800 rounded shadow whitespace-pre-line"
-        >
-          {content}
-        </div>
-      )}
+      <div
+        id={tooltipId}
+        role="tooltip"
+        className={[
+          'absolute z-10 p-2 text-xs text-white bg-gray-800 rounded shadow whitespace-pre-line',
+          visible ? '' : 'hidden',
+        ].join(' ')}
+      >
+        {content}
+      </div>
     </div>
   )
 }

--- a/tests/shared-event-tooltip.test.tsx
+++ b/tests/shared-event-tooltip.test.tsx
@@ -26,11 +26,12 @@ describe('SharedEventTooltip', () => {
       </SharedEventTooltip>
     )
     const trigger = document.querySelector('div[tabindex="0"]') as HTMLElement
+    const tooltip = document.querySelector('[role="tooltip"]') as HTMLElement
+    expect(tooltip.classList.contains('hidden')).toBe(true)
     act(() => {
       trigger.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }))
     })
-    const tooltip = document.querySelector('[role="tooltip"]') as HTMLElement
-    expect(tooltip).toBeTruthy()
+    expect(tooltip.classList.contains('hidden')).toBe(false)
     expect(tooltip.textContent).toContain('Invitees: Alice, Bob')
     expect(tooltip.textContent).toContain('Permissions: view, edit')
     expect(trigger.getAttribute('aria-describedby')).toBe(tooltip.id)
@@ -43,18 +44,17 @@ describe('SharedEventTooltip', () => {
       </SharedEventTooltip>
     )
     const trigger = document.querySelector('div[tabindex="0"]') as HTMLElement
+    const tooltip = document.querySelector('[role="tooltip"]') as HTMLElement
+    expect(tooltip.classList.contains('hidden')).toBe(true)
+    expect(trigger.getAttribute('aria-describedby')).toBe(tooltip.id)
     act(() => {
       trigger.focus()
     })
-    let tooltip = document.querySelector('[role="tooltip"]') as HTMLElement | null
-    expect(tooltip).toBeTruthy()
-    expect(trigger.getAttribute('aria-describedby')).toBe(tooltip!.id)
+    expect(tooltip.classList.contains('hidden')).toBe(false)
     act(() => {
       trigger.blur()
     })
-    tooltip = document.querySelector('[role="tooltip"]')
-    expect(tooltip).toBeNull()
-    expect(trigger.hasAttribute('aria-describedby')).toBe(false)
+    expect(tooltip.classList.contains('hidden')).toBe(true)
   })
 })
 


### PR DESCRIPTION
## Summary
- ensure SharedEventTooltip is always described with `aria-describedby` and renders a `role="tooltip"` container
- hide and reveal tooltip using class toggle for keyboard focus and hover
- add accessibility tests for hover and focus behaviors

## Testing
- `npm run lint`
- `npm test tests/shared-event-tooltip.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a32e973a6c8326861dcebaa86eab95