### PR TITLE
Add tests for task deletion broadcasts

### DIFF
--- a/tests/context-switcher.test.tsx
+++ b/tests/context-switcher.test.tsx
@@ -30,7 +30,8 @@ describe('ContextSwitcher', () => {
   })
 
   it('uses initial context from cookie', async () => {
-    document.cookie = 'context=group; groupId=team-b'
+    document.cookie = 'context=group'
+    document.cookie = 'groupId=team-b'
     const fetchMock = vi.fn()
     global.fetch = fetchMock as any
     render(<ContextSwitcher />)
@@ -69,7 +70,8 @@ describe('ContextSwitcher', () => {
   })
 
   it('updates cookie on selection change', async () => {
-    document.cookie = 'context=group; groupId=team-a'
+    document.cookie = 'context=group'
+    document.cookie = 'groupId=team-a'
     render(<ContextSwitcher />)
     await act(async () => {})
     const select = document.querySelector('select') as HTMLSelectElement

--- a/tests/finance-page.test.tsx
+++ b/tests/finance-page.test.tsx
@@ -149,7 +149,8 @@ describe('FinancePage', () => {
     });
     const { container } = render(<FinancePage />);
     expect(container.textContent).toContain('Rent');
-    document.cookie = 'context=group; groupId=team-a';
+    document.cookie = 'context=group';
+    document.cookie = 'groupId=team-a';
     act(() => {
       window.dispatchEvent(new Event('context-changed'));
     });

--- a/tests/task-delete.api.test.ts
+++ b/tests/task-delete.api.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { promises as fs } from 'fs'
+import os from 'os'
+import path from 'path'
+import { getServerSession } from 'next-auth'
+
+vi.mock('next-auth', async () => {
+  const actual = await vi.importActual<any>('next-auth')
+  return {
+    ...actual,
+    getServerSession: vi.fn(),
+  }
+})
+
+vi.mock('../lib/ws-server', async () => {
+  const actual = await vi.importActual<any>('../lib/ws-server')
+  return { ...actual, sendWsMessage: vi.fn() }
+})
+
+async function loadModules() {
+  vi.resetModules()
+  const schedule = await import('../app/api/schedule/route')
+  const task = await import('../app/api/task/[id]/route')
+  return { schedule, task }
+}
+
+describe('task delete API', () => {
+  const file = path.join(os.tmpdir(), 'events.delete.test.json')
+
+  afterEach(async () => {
+    await fs.unlink(file).catch(() => {})
+    delete process.env.SCHEDULE_DATA_FILE
+    vi.clearAllMocks()
+  })
+
+  it('deletes event and broadcasts message', async () => {
+    process.env.SCHEDULE_DATA_FILE = file
+    await fs.writeFile(file, JSON.stringify({ events: [], layers: [] }))
+
+    vi.mocked(getServerSession).mockResolvedValue({
+      user: { id: '1' },
+      accessToken: 'tok',
+    })
+
+    const {
+      schedule: { POST },
+      task: { DELETE, GET },
+    } = await loadModules()
+
+    const event = { id: 'd1', start: '2024-01-01', shared: false }
+    const postReq = new Request('http://test', {
+      method: 'POST',
+      body: JSON.stringify(event),
+      headers: { 'Content-Type': 'application/json', cookie: 'context=personal' },
+    })
+    await POST(postReq)
+
+    const delReq = new Request('http://test', {
+      method: 'DELETE',
+      headers: { cookie: 'context=personal' },
+    })
+    const delRes = await DELETE(delReq, { params: { id: event.id } })
+    expect(await delRes.json()).toEqual({ success: true })
+
+    const getRes = await GET(
+      new Request('http://test', { headers: { cookie: 'context=personal' } }),
+      { params: { id: event.id } },
+    )
+    expect(getRes.status).toBe(404)
+
+    const { sendWsMessage } = await import('../lib/ws-server')
+    expect(sendWsMessage).toHaveBeenCalledWith(
+      { type: 'calendar.event.deleted', id: event.id },
+      'tok',
+    )
+  })
+})
+


### PR DESCRIPTION
## Summary
- add tests ensuring task deletion persists and emits `calendar.event.deleted`
- set context and group cookies separately in tests so FinancePage and ContextSwitcher handle group context correctly

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a32e95f6b883269325a5b4433276e4