### PR TITLE
Display finance option deviations relative to optimal

### DIFF
--- a/app/finance/page.tsx
+++ b/app/finance/page.tsx
@@ -67,9 +67,6 @@ export default function FinancePage() {
   )
 
   const [selected, setSelected] = useState<typeof ranked[0] | null>(null)
-  const minCost = ranked.length
-    ? Math.min(...ranked.map((o) => o.costOfDeviation))
-    : Infinity
 
   return (
     <div className="p-4">
@@ -105,7 +102,7 @@ export default function FinancePage() {
       <div className="grid gap-4 md:grid-cols-2">
         {ranked.map((option, idx) => {
           const label = String.fromCharCode(65 + idx)
-          const isBest = option.costOfDeviation === minCost
+          const isBest = option.rank === 1
           return (
             <div
               key={option.category}
@@ -127,7 +124,7 @@ export default function FinancePage() {
                 )}
               </div>
               <p>Amount: ${option.amount}</p>
-              <p>Cost of deviation: ${isBest ? 0 : option.costOfDeviation}</p>
+              <p>Cost of deviation: ${option.costOfDeviation}</p>
               <button
                 className="mt-2 text-blue-500 underline"
                 onClick={() => {

--- a/lib/finance.ts
+++ b/lib/finance.ts
@@ -7,8 +7,15 @@ export type BudgetOption = {
 export type RankedBudgetOption = BudgetOption & { rank: number }
 
 export function rankBudgetOptions(options: BudgetOption[]): RankedBudgetOption[] {
-  return options
+  const sorted = options
     .slice()
     .sort((a, b) => a.costOfDeviation - b.costOfDeviation)
-    .map((option, idx) => ({ ...option, rank: idx + 1 }))
+
+  const baseCost = sorted.length ? sorted[0].costOfDeviation : 0
+
+  return sorted.map((option, idx) => ({
+    ...option,
+    costOfDeviation: option.costOfDeviation - baseCost,
+    rank: idx + 1,
+  }))
 }

--- a/tests/finance-page.test.tsx
+++ b/tests/finance-page.test.tsx
@@ -33,14 +33,15 @@ describe('FinancePage', () => {
     send = vi.fn();
     financeUpdate = null;
     document.cookie = 'groupId=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/';
+    document.cookie = 'context=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/';
   });
 
   it('labels options, highlights best choice, and shows modal content', () => {
     const mutate = vi.fn();
     swrMock = vi.fn(() => ({
       data: [
-        { category: 'Rent', amount: 1000, costOfDeviation: 0 },
-        { category: 'Food', amount: 500, costOfDeviation: 100 },
+        { category: 'Rent', amount: 960, costOfDeviation: 0 },
+        { category: 'Food', amount: 910, costOfDeviation: 0 },
       ],
       mutate,
     }));
@@ -57,7 +58,7 @@ describe('FinancePage', () => {
     const costInfoBest = cards[0].querySelector('p:nth-of-type(2)') as HTMLParagraphElement;
     expect(costInfoBest.textContent).toBe('Cost of deviation: $0');
     const costInfo = cards[1].querySelector('p:nth-of-type(2)') as HTMLParagraphElement;
-    expect(costInfo.textContent).toMatch(/Cost of deviation:/);
+    expect(costInfo.textContent).toBe('Cost of deviation: $50');
     const viewBtn = cards[0].querySelector('button') as HTMLButtonElement;
     act(() => { viewBtn.click(); });
     expect(send).toHaveBeenCalledWith(
@@ -132,7 +133,7 @@ describe('FinancePage', () => {
   });
 
   it('loads new data when the context cookie changes', () => {
-    document.cookie = 'context=personal';
+    document.cookie = 'context=personal; path=/';
     const mutate = vi.fn();
     swrMock = vi.fn((key: string) => {
       const matchCtx = key.match(/context=([^&]+)/);
@@ -149,7 +150,8 @@ describe('FinancePage', () => {
     });
     const { container } = render(<FinancePage />);
     expect(container.textContent).toContain('Rent');
-    document.cookie = 'context=group; groupId=team-a';
+    document.cookie = 'context=group; path=/';
+    document.cookie = 'groupId=team-a; path=/';
     act(() => {
       window.dispatchEvent(new Event('context-changed'));
     });


### PR DESCRIPTION
## Summary
- Normalize `rankBudgetOptions` so each option's deviation is relative to the lowest-cost option
- Show zero deviation for the top-ranked finance option and positive deviations for others
- Extend finance page tests to verify relative deviation calculation

## Testing
- `npm run lint`
- `npm test tests/finance-page.test.tsx tests/rank-options.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a336d1a6848326ae66d817c3299281