### PR TITLE
test: add connection status tests

### DIFF
--- a/app/components/ConnectionStatus.tsx
+++ b/app/components/ConnectionStatus.tsx
@@ -2,17 +2,23 @@
 import React from 'react';
 import { useSocketStatus } from '../socket-context';
 
+export function getConnectionStatusMessage(
+  connectionState: string,
+  lastError?: { code: string | number; message: string } | null
+) {
+  return connectionState === 'connecting'
+    ? 'Connecting...'
+    : `Connection error${
+        lastError ? ` (${lastError.code}: ${lastError.message})` : ''
+      }`;
+}
+
 export default function ConnectionStatus() {
   const { connectionState, lastError, retry } = useSocketStatus();
 
   if (connectionState === 'open') return null;
 
-  const message =
-    connectionState === 'connecting'
-      ? 'Connecting...'
-      : `Connection error${
-          lastError ? ` (${lastError.code}: ${lastError.message})` : ''
-        }`;
+  const message = getConnectionStatusMessage(connectionState, lastError);
 
   return (
     <div

--- a/tests/connection-status.test.tsx
+++ b/tests/connection-status.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { act } from 'react-dom/test-utils'
+import ConnectionStatus, { getConnectionStatusMessage } from '../app/components/ConnectionStatus'
+
+let socketStatusMock: any
+vi.mock('../app/socket-context', () => ({
+  useSocketStatus: () => socketStatusMock,
+}))
+
+function render(ui: React.ReactElement) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = ReactDOM.createRoot(container)
+  act(() => {
+    root.render(ui)
+  })
+  return { container, root }
+}
+
+describe('ConnectionStatus', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true)
+  })
+
+  it('displays connecting message', () => {
+    socketStatusMock = { connectionState: 'connecting', lastError: null, retry: vi.fn() }
+    const { container } = render(<ConnectionStatus />)
+    expect(container.textContent).toBe(
+      getConnectionStatusMessage('connecting')
+    )
+  })
+
+  it('displays error message and retries on click', () => {
+    const retry = vi.fn()
+    const lastError = { code: '500', message: 'fail' }
+    socketStatusMock = { connectionState: 'error', lastError, retry }
+    const { container } = render(<ConnectionStatus />)
+    const div = container.querySelector('div') as HTMLDivElement
+    expect(div.textContent).toBe(
+      getConnectionStatusMessage('error', lastError)
+    )
+    act(() => {
+      div.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(retry).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- export helper to generate connection status messages for easier testing
- add tests covering connecting and error states with retry callback

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a491675aa4832684653b170a653dba