### PR TITLE
refactor: centralize group permission checks

### DIFF
--- a/lib/permissions.ts
+++ b/lib/permissions.ts
@@ -1,0 +1,28 @@
+export interface GroupedEvent {
+  shared?: boolean
+  groupId?: string | null
+}
+
+export function validateGroupPermissions(
+  session: any,
+  ctx: string,
+  groupId?: string,
+  event?: GroupedEvent,
+): Response | undefined {
+  if (ctx === 'group') {
+    if (!groupId) {
+      return new Response('groupId required', { status: 400 })
+    }
+    const groups: string[] = session.groups ?? []
+    if (!groups.includes(groupId)) {
+      return new Response('Forbidden', { status: 403 })
+    }
+    if (event) {
+      if (!event.shared || !event.groupId || event.groupId !== groupId) {
+        return new Response('Forbidden', { status: 403 })
+      }
+    }
+  } else if (event?.shared) {
+    return new Response('Forbidden', { status: 403 })
+  }
+}


### PR DESCRIPTION
## Summary
- add `validateGroupPermissions` helper for group context and event access
- use helper in schedule and task API routes
- expand schedule group permissions test to cover helper

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a70597a6388326a1613791ee9cf075