### PR TITLE
feat: add greet CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,20 @@ The app will be available at `http://localhost:3000`.
 - Run `npm run lint` to check code style.
 - Run `npm run test` to execute unit tests with Vitest.
 
+## Greet CLI Command
+
+Use the `greet` command to print a greeting message.
+
+```bash
+npm run greet
+```
+
+By default, this prints `Hello, Constellation!`. Supply a custom message with the `--message` flag:
+
+```bash
+npm run greet -- --message "Hi there!"
+```
+
 ## Environment Variables
 
 - `NEXT_PUBLIC_WS_URL` &ndash; WebSocket server URL used by the dashboard. Defaults to `ws://localhost:3001` if not provided.

--- a/bin/greet.js
+++ b/bin/greet.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+"use strict";
+
+// Simple CLI to print a greeting message.
+const args = process.argv.slice(2);
+let message = "Hello, Constellation!";
+
+for (let i = 0; i < args.length; i++) {
+  const arg = args[i];
+  if (arg === "--message" && i + 1 < args.length) {
+    message = args[i + 1];
+    i++;
+  } else if (arg.startsWith("--message=")) {
+    message = arg.split("=")[1];
+  }
+}
+
+console.log(message);

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "NODE_OPTIONS=--max-old-space-size=8192 vitest run"
-
+    "test": "NODE_OPTIONS=--max-old-space-size=8192 vitest run",
+    "greet": "node bin/greet.js"
   },
   "keywords": [],
   "author": "",
@@ -40,5 +40,8 @@
     "tailwindcss": "^3.4.17",
     "typescript": "5.9.2",
     "vitest": "^3.2.4"
+  },
+  "bin": {
+    "greet": "./bin/greet.js"
   }
 }


### PR DESCRIPTION
## Summary
- add `greet` CLI for customizable greeting messages
- document new `greet` command in README
- expose `greet` script and bin entry in `package.json`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a728ce57fc8326a907ce8ff925b729