### PR TITLE
Enable React act environment for Vitest

### DIFF
--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,5 @@
+// Vitest setup file
+// Tell React that the testing environment supports `act`.
+// Without this, React 19 warns that "The current testing environment is not configured to support act(...)".
+// Setting this global enables React's built-in act behavior in our tests.
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,5 +3,8 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'jsdom',
+    // Ensure React's `act` is enabled in the Vitest environment
+    // by executing our setup file before each test suite.
+    setupFiles: './tests/setup.ts',
   },
 });


### PR DESCRIPTION
## Summary
- Configure Vitest to run `tests/setup.ts` before suites
- Mark test environment as React `act` aware to silence warnings

## Testing
- `npm run lint`
- `npm test -- tests/basic.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ac781814ec83269dd95c66c8d27f60