### PR TITLE
feat: emit latest task status to new subscribers

### DIFF
--- a/lib/taskCascadence.ts
+++ b/lib/taskCascadence.ts
@@ -54,13 +54,18 @@ function ensureConnection() {
 
 export function subscribeToTaskStatus(callback: Callback) {
   callbacks.add(callback)
+  if (latestStatus) {
+    callback(latestStatus)
+  }
   ensureConnection()
   return () => {
     callbacks.delete(callback)
-    if (!callbacks.size && ws) {
+    if (!callbacks.size) {
       shouldReconnect = false
-      ws.close()
-      ws = null
+      if (ws) {
+        ws.close()
+        ws = null
+      }
       if (reconnectTimeout) {
         clearTimeout(reconnectTimeout)
         reconnectTimeout = null


### PR DESCRIPTION
## Summary
- ensure new task-status subscribers immediately receive last known status
- clear reconnect timers when no listeners remain to avoid lingering timeouts

## Testing
- `NEXT_PUBLIC_TASK_CASCADENCE_WS_URL=ws://example.com npx vitest run --reporter=default`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ada97e8bf483268a830ceeb41a778a