### PR TITLE
Add label and placeholder for calendar NL field

### DIFF
--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -152,8 +152,13 @@ export default function CalendarPage() {
   return (
     <div>
       <form onSubmit={handleNL} className="mb-4">
+        <label htmlFor="nl" className="mr-2">
+          Describe your event
+        </label>
         <input
+          id="nl"
           name="nl"
+          placeholder="Lunch with Mark tomorrow at noon"
           value={nl}
           onChange={e => setNl(e.target.value)}
           className="border mr-2"

--- a/tests/calendar-page.test.tsx
+++ b/tests/calendar-page.test.tsx
@@ -52,6 +52,18 @@ describe('CalendarPage', () => {
     document.cookie = 'groupId=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/';
   });
 
+  it('renders NL field with label and placeholder', () => {
+    const mutate = vi.fn();
+    swrMock = vi.fn(() => ({ data: { events: [], layers: [] }, mutate }));
+    const { container } = render(<CalendarPage />);
+
+    const label = container.querySelector('label[for="nl"]');
+    expect(label?.textContent).toBe('Describe your event');
+
+    const input = container.querySelector('input[name="nl"]') as HTMLInputElement;
+    expect(input.placeholder).toBe('Lunch with Mark tomorrow at noon');
+  });
+
   it('configures multiple calendar views', () => {
     const mutate = vi.fn();
     swrMock = vi.fn(() => ({ data: { events: [], layers: [] }, mutate }));


### PR DESCRIPTION
## Summary
- add accessible label and example placeholder for natural language event input on calendar page
- test NL input label and placeholder

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af079535788326938e9a57cf65372d