### PR TITLE
feat: add auth middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+import { getToken } from 'next-auth/jwt'
+
+const publicRoutes = ['/login', '/api/auth']
+
+export async function middleware(req: NextRequest) {
+  const { pathname } = req.nextUrl
+
+  if (publicRoutes.some((route) => pathname.startsWith(route))) {
+    return NextResponse.next()
+  }
+
+  const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET })
+
+  if (!token) {
+    const url = req.nextUrl.clone()
+    url.pathname = '/login'
+    return NextResponse.redirect(url)
+  }
+
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: ['/((?!_next/static|_next/image|favicon.ico).*)'],
+}

--- a/tests/middleware.test.ts
+++ b/tests/middleware.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('next-auth/jwt', () => ({
+  getToken: vi.fn(),
+}))
+
+import { getToken } from 'next-auth/jwt'
+import { middleware } from '../middleware'
+
+function mockGetToken(value: any) {
+  ;(getToken as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(value)
+}
+
+describe('middleware', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('redirects unauthenticated requests to /login', async () => {
+    mockGetToken(null)
+    const req = new NextRequest('http://localhost/dashboard')
+    const res = await middleware(req)
+    expect(res.status).toBe(307)
+    expect(res.headers.get('location')).toBe('http://localhost/login')
+  })
+
+  it('allows access to public routes', async () => {
+    mockGetToken(null)
+    const req = new NextRequest('http://localhost/login')
+    const res = await middleware(req)
+    expect(res.status).toBe(200)
+    expect(res.headers.get('location')).toBeNull()
+  })
+
+  it('allows authenticated requests', async () => {
+    mockGetToken({ sub: '1' })
+    const req = new NextRequest('http://localhost/dashboard')
+    const res = await middleware(req)
+    expect(res.status).toBe(200)
+  })
+})


### PR DESCRIPTION
## Summary
- add middleware that enforces authentication using next-auth's `getToken`
- redirect unauthenticated traffic to `/login` while allowing public routes
- test middleware redirection logic

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af1d3750f083268e33a7ef427dba7e