### PR TITLE
feat: add calendar sidebar

### DIFF
--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useMemo } from 'react'
 import useSWR from 'swr'
 import { fetcher } from '../../lib/swr'
 import { AppContext } from '../../lib/context'
@@ -51,6 +51,26 @@ export default function CalendarPage() {
   const [error, setError] = useState<string | null>(null)
   const [selectedLayers, setSelectedLayers] = useState<string[]>([])
   const [layer, setLayer] = useState('')
+  const userColors = useMemo(() => {
+    const owners = Array.from(new Set(data.events.map(e => e.owner).filter(Boolean))) as string[]
+    const palette = [
+      '#1f77b4',
+      '#ff7f0e',
+      '#2ca02c',
+      '#d62728',
+      '#9467bd',
+      '#8c564b',
+      '#e377c2',
+      '#7f7f7f',
+      '#bcbd22',
+      '#17becf',
+    ]
+    const map: Record<string, string> = {}
+    owners.forEach((owner, idx) => {
+      map[owner] = palette[idx % palette.length]
+    })
+    return map
+  }, [data.events])
 
   const socket = useSocket()
   const calendarEvent = useCalendarEvents()
@@ -150,89 +170,96 @@ export default function CalendarPage() {
   }
 
   return (
-    <div>
-      <form onSubmit={handleNL} className="mb-4">
-        <label htmlFor="nl" className="mr-2">
-          Describe your event
-        </label>
-        <input
-          id="nl"
-          name="nl"
-          placeholder="Lunch with Mark tomorrow at noon"
-          value={nl}
-          onChange={e => setNl(e.target.value)}
-          className="border mr-2"
-        />
-        <button type="submit" className="border px-2">Send</button>
-      </form>
-      <CalendarLayerPanel layers={data.layers} selected={selectedLayers} onToggle={toggleLayer} />
-      <form onSubmit={handleCreate} className="mb-4">
-        <input
-          name="title"
-          placeholder="Title"
-          value={title}
-          onChange={e => setTitle(e.target.value)}
-          className="border mr-2"
-        />
-        <input
-          name="start"
-          type="date"
-          value={start}
-          onChange={e => setStart(e.target.value)}
-          className="border mr-2"
-        />
-        <input
-          name="end"
-          type="date"
-          value={end}
-          onChange={e => setEnd(e.target.value)}
-          className="border mr-2"
-        />
-        <input
-          name="invitees"
-          placeholder="Invitees"
-          value={invitees}
-          onChange={e => setInvitees(e.target.value)}
-          className="border mr-2"
-        />
-        <input
-          name="permissions"
-          placeholder="Permissions"
-          value={permissions}
-          onChange={e => setPermissions(e.target.value)}
-          className="border mr-2"
-        />
-        <select
-          name="layer"
-          value={layer}
-          onChange={e => setLayer(e.target.value)}
-          className="border mr-2"
-        >
-          {data.layers.map(l => (
-            <option key={l.id} value={l.id}>
-              {l.name}
-            </option>
-          ))}
-        </select>
-        <label className="mr-2">
-          <input
-            name="shared"
-            type="checkbox"
-            checked={shared}
-            onChange={e => setShared(e.target.checked)}
-            className="mr-1"
-          />
-          Shared
-        </label>
-        <button type="submit" className="border px-2">Add</button>
-      </form>
-      {error && <p role="alert" className="text-red-500">{error}</p>}
-      <ScheduleCalendar
-        events={data.events}
+    <div className="flex">
+      <CalendarLayerPanel
         layers={data.layers}
-        visibleLayers={selectedLayers}
-        mutate={mutate}
+        selected={selectedLayers}
+        onToggle={toggleLayer}
+        userColors={userColors}
       />
+      <div className="flex-1">
+        <form onSubmit={handleNL} className="mb-4">
+          <label htmlFor="nl" className="mr-2">
+            Describe your event
+          </label>
+          <input
+            id="nl"
+            name="nl"
+            placeholder="Lunch with Mark tomorrow at noon"
+            value={nl}
+            onChange={e => setNl(e.target.value)}
+            className="border mr-2"
+          />
+          <button type="submit" className="border px-2">Send</button>
+        </form>
+        <form onSubmit={handleCreate} className="mb-4">
+          <input
+            name="title"
+            placeholder="Title"
+            value={title}
+            onChange={e => setTitle(e.target.value)}
+            className="border mr-2"
+          />
+          <input
+            name="start"
+            type="date"
+            value={start}
+            onChange={e => setStart(e.target.value)}
+            className="border mr-2"
+          />
+          <input
+            name="end"
+            type="date"
+            value={end}
+            onChange={e => setEnd(e.target.value)}
+            className="border mr-2"
+          />
+          <input
+            name="invitees"
+            placeholder="Invitees"
+            value={invitees}
+            onChange={e => setInvitees(e.target.value)}
+            className="border mr-2"
+          />
+          <input
+            name="permissions"
+            placeholder="Permissions"
+            value={permissions}
+            onChange={e => setPermissions(e.target.value)}
+            className="border mr-2"
+          />
+          <select
+            name="layer"
+            value={layer}
+            onChange={e => setLayer(e.target.value)}
+            className="border mr-2"
+          >
+            {data.layers.map(l => (
+              <option key={l.id} value={l.id}>
+                {l.name}
+              </option>
+            ))}
+          </select>
+          <label className="mr-2">
+            <input
+              name="shared"
+              type="checkbox"
+              checked={shared}
+              onChange={e => setShared(e.target.checked)}
+              className="mr-1"
+            />
+            Shared
+          </label>
+          <button type="submit" className="border px-2">Add</button>
+        </form>
+        {error && <p role="alert" className="text-red-500">{error}</p>}
+        <ScheduleCalendar
+          events={data.events}
+          layers={data.layers}
+          visibleLayers={selectedLayers}
+          mutate={mutate}
+        />
+      </div>
     </div>
   )
 }

--- a/app/components/CalendarLayerPanel.tsx
+++ b/app/components/CalendarLayerPanel.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import React from 'react'
+import LayerLegend from './LayerLegend'
+import UserLegend from './UserLegend'
 
 interface Layer {
   id: string
@@ -12,27 +14,32 @@ interface CalendarLayerPanelProps {
   layers: Layer[]
   selected: string[]
   onToggle: (id: string) => void
+  userColors?: Record<string, string>
 }
 
-export default function CalendarLayerPanel({ layers, selected, onToggle }: CalendarLayerPanelProps) {
+export default function CalendarLayerPanel({ layers, selected, onToggle, userColors = {} }: CalendarLayerPanelProps) {
   return (
-    <div className="mb-4">
-      {layers.map(layer => (
-        <label key={layer.id} className="flex items-center space-x-2 mb-1">
-          <input
-            type="checkbox"
-            checked={selected.includes(layer.id)}
-            onChange={() => onToggle(layer.id)}
-          />
-          <span
-            className="w-3 h-3 inline-block"
-            style={{ backgroundColor: layer.color }}
-            aria-hidden="true"
-          />
-          <span className="sr-only">Color: {layer.color}</span>
-          <span>{layer.name}</span>
-        </label>
-      ))}
-    </div>
+    <aside className="w-64 flex-shrink-0 mr-4 flex flex-col gap-4">
+      <div>
+        {layers.map(layer => (
+          <label key={layer.id} className="flex items-center space-x-2 mb-1">
+            <input
+              type="checkbox"
+              checked={selected.includes(layer.id)}
+              onChange={() => onToggle(layer.id)}
+            />
+            <span
+              className="w-3 h-3 inline-block"
+              style={{ backgroundColor: layer.color }}
+              aria-hidden="true"
+            />
+            <span className="sr-only">Color: {layer.color}</span>
+            <span>{layer.name}</span>
+          </label>
+        ))}
+      </div>
+      <LayerLegend layers={layers} />
+      <UserLegend userColors={userColors} />
+    </aside>
   )
 }

--- a/app/components/ScheduleCalendar.tsx
+++ b/app/components/ScheduleCalendar.tsx
@@ -8,8 +8,6 @@ import interactionPlugin, { EventDropArg, DateClickArg } from '@fullcalendar/int
 import { EventContentArg, EventMountArg } from '@fullcalendar/core'
 import { useCalendarEvents, useTaskStatus } from '../socket-context'
 import SharedEventTooltip from './SharedEventTooltip'
-import UserLegend from './UserLegend'
-import LayerLegend from './LayerLegend'
 
 interface Layer {
   id: string
@@ -324,8 +322,6 @@ export default function ScheduleCalendar({ events, layers, visibleLayers, mutate
           </div>
         ))}
       </div>
-      <LayerLegend layers={layers} />
-      <UserLegend userColors={userColors} />
     </div>
   )
 }

--- a/tests/schedule-legend.test.tsx
+++ b/tests/schedule-legend.test.tsx
@@ -1,20 +1,8 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach } from 'vitest'
 import { act } from 'react-dom/test-utils'
-import ScheduleCalendar from '../app/components/ScheduleCalendar'
-
-vi.mock('../app/socket-context', () => ({
-  __esModule: true,
-  useCalendarEvents: () => null,
-  useTaskStatus: () => null,
-  useSocketStatus: () => ({ connectionState: 'open', lastError: null, retry: () => {} }),
-}))
-
-vi.mock('@fullcalendar/react', () => ({
-  __esModule: true,
-  default: () => React.createElement('div')
-}))
+import CalendarLayerPanel from '../app/components/CalendarLayerPanel'
 
 function render(ui: React.ReactElement) {
   const container = document.createElement('div')
@@ -26,17 +14,22 @@ function render(ui: React.ReactElement) {
   return { container, root }
 }
 
-describe('ScheduleCalendar legends', () => {
+describe('Sidebar legends', () => {
   beforeEach(() => {
     document.body.innerHTML = ''
   })
 
   it('displays layer and user legends', () => {
     const layers = [{ id: 'l1', name: 'Layer 1', color: '#f00' }]
-    const events = [
-      { id: '1', title: 'A', start: '2024-05-20T10:00:00', owner: 'alice', layer: 'l1' },
-    ]
-    render(<ScheduleCalendar events={events} layers={layers} visibleLayers={['l1']} mutate={() => {}} />)
+    const userColors = { alice: '#0f0' }
+    render(
+      <CalendarLayerPanel
+        layers={layers}
+        selected={['l1']}
+        onToggle={() => {}}
+        userColors={userColors}
+      />
+    )
     const layerLegend = document.querySelector('[aria-label="Layer color legend"]') as HTMLElement
     expect(layerLegend).toBeTruthy()
     expect(layerLegend.textContent).toContain('Layer 1')
@@ -45,3 +38,4 @@ describe('ScheduleCalendar legends', () => {
     expect(userLegend.textContent).toContain('AL')
   })
 })
+


### PR DESCRIPTION
## Summary
- redesign CalendarLayerPanel as a sidebar with layer/user legends
- compute user color mapping and render calendar next to sidebar
- relocate schedule legend test to sidebar

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6e476c3488326a7552b1a58e80f85