### PR TITLE
Include context and user in finance socket requests

### DIFF
--- a/app/finance/page.tsx
+++ b/app/finance/page.tsx
@@ -5,6 +5,7 @@ import { fetcher } from '../../lib/swr'
 import { BudgetOption, rankBudgetOptions } from '../../lib/finance'
 import { useFinanceUpdates, useSocket } from '../socket-context'
 import { getClientContext } from '../../lib/client-context'
+import { useSession } from 'next-auth/react'
 
 export default function FinancePage() {
   const [budget, setBudget] = useState(1000)
@@ -18,6 +19,7 @@ export default function FinancePage() {
 
   const update = useFinanceUpdates()
   const socket = useSocket()
+  const { data: session } = useSession()
   const [paymentSchedules, setPaymentSchedules] = useState<Record<string, any[]>>({})
   const [aiExplanations, setAiExplanations] = useState<Record<string, string>>({})
   useEffect(() => {
@@ -133,12 +135,18 @@ export default function FinancePage() {
                     JSON.stringify({
                       type: 'finance.decision.request',
                       category: option.category,
+                      context,
+                      groupId,
+                      user: session?.user?.id,
                     }),
                   )
                   socket?.send(
                     JSON.stringify({
                       type: 'finance.explain.request',
                       category: option.category,
+                      context,
+                      groupId,
+                      user: session?.user?.id,
                     }),
                   )
                 }}


### PR DESCRIPTION
## Summary
- include session-based user along with context and group ID in finance socket requests
- test finance page and socket events for context and user fields

## Testing
- `npm run lint`
- `npm test tests/finance-page.test.tsx tests/socket-events.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b72cff17508326b99bafa3814cc60a