### PR TITLE
feat: announce connection status politely

### DIFF
--- a/app/components/ConnectionStatus.tsx
+++ b/app/components/ConnectionStatus.tsx
@@ -25,6 +25,7 @@ export default function ConnectionStatus() {
       style={{ cursor: 'pointer', color: 'red' }}
       onClick={() => retry()}
       role="button"
+      aria-live="polite"
     >
       {message}
     </div>

--- a/tests/connection-status.test.tsx
+++ b/tests/connection-status.test.tsx
@@ -33,6 +33,13 @@ describe('ConnectionStatus', () => {
     )
   })
 
+  it('marks status message as polite live region', () => {
+    socketStatusMock = { connectionState: 'error', lastError: null, retry: vi.fn() }
+    const { container } = render(<ConnectionStatus />)
+    const div = container.querySelector('div') as HTMLDivElement
+    expect(div.getAttribute('aria-live')).toBe('polite')
+  })
+
   it('displays error message and retries on click', () => {
     const retry = vi.fn()
     const lastError = { code: '500', message: 'fail' }


### PR DESCRIPTION
## Summary
- add `aria-live="polite"` to connection status container
- test for polite live region

## Testing
- `npm test tests/connection-status.test.tsx`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b75b42e5e88326858890dde74db4e4