### PR TITLE
feat: highlight shared events

### DIFF
--- a/app/components/ScheduleCalendar.tsx
+++ b/app/components/ScheduleCalendar.tsx
@@ -168,7 +168,7 @@ export default function ScheduleCalendar({ events, layers, visibleLayers, mutate
       return
     }
     if (shared) {
-      info.el.classList.add('border-2', 'border-dashed')
+      info.el.classList.add('border-2', 'border-dashed', 'border-blue-500')
       const icon = document.createElement('span')
       icon.textContent = '👥'
       icon.className = 'mr-1'
@@ -177,7 +177,9 @@ export default function ScheduleCalendar({ events, layers, visibleLayers, mutate
     const layerColor = info.event.extendedProps.layerColor || info.event.backgroundColor
     if (layerColor) {
       info.el.style.backgroundColor = layerColor
-      info.el.style.borderColor = layerColor
+      if (!shared) {
+        info.el.style.borderColor = layerColor
+      }
     }
   }
 

--- a/tests/schedule-colors.test.tsx
+++ b/tests/schedule-colors.test.tsx
@@ -12,10 +12,12 @@ vi.mock('../app/socket-context', () => ({
 }))
 
 let capturedEvents: any[] = []
+let capturedEventDidMount: any = null
 vi.mock('@fullcalendar/react', () => ({
   __esModule: true,
   default: (props: any) => {
     capturedEvents = props.events
+    capturedEventDidMount = props.eventDidMount
     return React.createElement('div')
   },
 }))
@@ -34,6 +36,7 @@ describe('ScheduleCalendar color scheme', () => {
   beforeEach(() => {
     document.body.innerHTML = ''
     capturedEvents = []
+    capturedEventDidMount = null
   })
 
   it('uses layer colors for background and user colors separately', () => {
@@ -47,5 +50,17 @@ describe('ScheduleCalendar color scheme', () => {
     expect(event.backgroundColor).toBe('#f00')
     expect(event.borderColor).toBe('#f00')
     expect(event.userColor).toBe('#1f77b4')
+  })
+
+  it('applies shared border class', () => {
+    const layers: any[] = []
+    const events = [
+      { id: 'e2', title: 'Shared', start: '2024-05-20T10:00:00', shared: true },
+    ]
+    render(<ScheduleCalendar events={events} layers={layers} visibleLayers={[]} mutate={() => {}} />)
+    const el = document.createElement('div')
+    const event = capturedEvents.find((e: any) => e.id === 'e2')
+    capturedEventDidMount({ event: { extendedProps: event }, el, view: { type: 'timeGridWeek' } })
+    expect(el.classList.contains('border-blue-500')).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary
- add distinct dashed blue border to shared events in ScheduleCalendar
- test shared events include border class

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b75b4282648326aef5cefbd5744ac1