### PR TITLE
feat: add finance interfaces

### DIFF
--- a/app/components/ScheduleCalendar.tsx
+++ b/app/components/ScheduleCalendar.tsx
@@ -2,10 +2,10 @@
 
 import React, { useEffect, useState, useMemo } from 'react'
 import FullCalendar from '@fullcalendar/react'
-import dayGridPlugin, { DayCellContentArg } from '@fullcalendar/daygrid'
+import dayGridPlugin from '@fullcalendar/daygrid'
 import timeGridPlugin from '@fullcalendar/timegrid'
-import interactionPlugin, { EventDropArg, DateClickArg } from '@fullcalendar/interaction'
-import { EventContentArg, EventMountArg } from '@fullcalendar/core'
+import interactionPlugin, { DateClickArg } from '@fullcalendar/interaction'
+import { DayCellContentArg, EventContentArg, EventMountArg, EventDropArg } from '@fullcalendar/core'
 import { useCalendarEvents, useTaskStatus } from '../socket-context'
 import SharedEventTooltip from './SharedEventTooltip'
 

--- a/app/finance/page.tsx
+++ b/app/finance/page.tsx
@@ -2,7 +2,12 @@
 import React, { useState, useEffect, useRef } from 'react'
 import useSWR from 'swr'
 import { fetcher } from '../../lib/swr'
-import { BudgetOption, rankBudgetOptions } from '../../lib/finance'
+import {
+  BudgetOption,
+  rankBudgetOptions,
+  PaymentScheduleItem,
+  FinanceUpdate,
+} from '../../lib/finance'
 import { useFinanceUpdates, useSocket } from '../socket-context'
 import { getClientContext } from '../../lib/client-context'
 import { useSession } from 'next-auth/react'
@@ -17,10 +22,13 @@ export default function FinancePage() {
     { refreshInterval: 30000 },
   )
 
-  const update = useFinanceUpdates()
+  const update = useFinanceUpdates() as FinanceUpdate | null
   const socket = useSocket()
   const { data: session } = useSession()
-  const [paymentSchedules, setPaymentSchedules] = useState<Record<string, any[]>>({})
+  const userId = (session?.user as { id?: string } | undefined)?.id
+  const [paymentSchedules, setPaymentSchedules] = useState<
+    Record<string, PaymentScheduleItem[]>
+  >({})
   const [aiExplanations, setAiExplanations] = useState<Record<string, string>>({})
   useEffect(() => {
     const handleContextChange = () => {
@@ -137,7 +145,7 @@ export default function FinancePage() {
                       category: option.category,
                       context,
                       groupId,
-                      user: session?.user?.id,
+                      user: userId,
                     }),
                   )
                   socket?.send(
@@ -146,7 +154,7 @@ export default function FinancePage() {
                       category: option.category,
                       context,
                       groupId,
-                      user: session?.user?.id,
+                      user: userId,
                     }),
                   )
                 }}
@@ -164,7 +172,7 @@ export default function FinancePage() {
             {paymentSchedules[selected.category] ? (
               <ul className="mb-2 list-disc pl-5">
                 {paymentSchedules[selected.category].map((item, i) => (
-                  <li key={i}>{typeof item === 'string' ? item : JSON.stringify(item)}</li>
+                  <li key={i}>{item.description}</li>
                 ))}
               </ul>
             ) : (

--- a/lib/finance.ts
+++ b/lib/finance.ts
@@ -6,6 +6,26 @@ export type BudgetOption = {
 
 export type RankedBudgetOption = BudgetOption & { rank: number }
 
+export interface PaymentScheduleItem {
+  description: string
+  amount?: number
+  dueDate?: string
+}
+
+export interface FinanceUpdate {
+  type: 'finance.decision.result' | 'finance.explain.result'
+  category?: string
+  paymentSchedule?: PaymentScheduleItem[]
+  schedule?: PaymentScheduleItem[]
+  explanation?: string
+  message?: string
+  data?: {
+    category?: string
+    paymentSchedule?: PaymentScheduleItem[]
+    explanation?: string
+  }
+}
+
 export function rankBudgetOptions(options: BudgetOption[]): RankedBudgetOption[] {
   const sorted = options
     .slice()

--- a/tests/finance-page.test.tsx
+++ b/tests/finance-page.test.tsx
@@ -2,11 +2,15 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { act } from 'react-dom/test-utils';
+import { PaymentScheduleItem, FinanceUpdate } from '../lib/finance';
 
-let swrMock: any;
-let send: any;
-let financeUpdate: any;
-vi.mock('swr', () => ({ __esModule: true, default: (...args: any[]) => swrMock(...args) }));
+let swrMock: ReturnType<typeof vi.fn>;
+let send: ReturnType<typeof vi.fn>;
+let financeUpdate: FinanceUpdate | null;
+vi.mock('swr', () => ({
+  __esModule: true,
+  default: (...args: unknown[]) => swrMock(...(args as any)),
+}));
 vi.mock('../app/socket-context', () => ({
   __esModule: true,
   useFinanceUpdates: () => financeUpdate,
@@ -102,7 +106,7 @@ describe('FinancePage', () => {
     financeUpdate = {
       type: 'finance.decision.result',
       category: 'Rent',
-      paymentSchedule: ['Installment 1'],
+      paymentSchedule: [{ description: 'Installment 1' } as PaymentScheduleItem],
     };
     act(() => {
       root.render(<FinancePage />);

--- a/tests/socket-events.test.tsx
+++ b/tests/socket-events.test.tsx
@@ -17,8 +17,11 @@ vi.mock('@fullcalendar/daygrid', () => ({ __esModule: true, default: {} }));
 vi.mock('@fullcalendar/timegrid', () => ({ __esModule: true, default: {} }));
 vi.mock('@fullcalendar/interaction', () => ({ __esModule: true, default: {}, EventDropArg: class {} }));
 
-let swrMock: any;
-vi.mock('swr', () => ({ __esModule: true, default: (...args: any[]) => swrMock(...args) }));
+let swrMock: ReturnType<typeof vi.fn>;
+vi.mock('swr', () => ({
+  __esModule: true,
+  default: (...args: unknown[]) => swrMock(...(args as any)),
+}));
 
 function render(ui: React.ReactElement) {
   const container = document.createElement('div');
@@ -164,7 +167,7 @@ describe('socket event propagation', () => {
         data: JSON.stringify({
           type: 'finance.decision.result',
           category: 'Rent',
-          paymentSchedule: ['due now'],
+          paymentSchedule: [{ description: 'due now' }],
         }),
       });
     });


### PR DESCRIPTION
## Summary
- add `PaymentScheduleItem` and `FinanceUpdate` interfaces
- type `FinancePage` payment schedules and explanations
- update finance-related tests for new types
- fix FullCalendar imports and session user typing to satisfy TypeScript

## Testing
- `npm test`
- `npm run lint`
- `npx tsc --noEmit --skipLibCheck --target es2017 --jsx react --moduleResolution node --esModuleInterop --lib dom,dom.iterable,esnext app/finance/page.tsx tests/finance-page.test.tsx tests/socket-events.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b842902cf883269aac86ba67b8b5c5